### PR TITLE
fix(server): if paused, send new state to observers only

### DIFF
--- a/sdk/src/server-api/sc/api/plugins/host/IGameListener.java
+++ b/sdk/src/server-api/sc/api/plugins/host/IGameListener.java
@@ -10,7 +10,7 @@ import sc.shared.PlayerScore;
 public interface IGameListener {
   void onGameOver(Map<Player, PlayerScore> results) throws InvalidScoreDefinitionException;
 
-  void onStateChanged(IGameState data);
+  void onStateChanged(IGameState data, boolean observersOnly);
 
   void onPaused(Player nextPlayer);
 }

--- a/sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
+++ b/sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
@@ -166,10 +166,8 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
       turn++;
     }
     this.activePlayer = nextPlayer;
-    // don't notify on new state if game is paused or client may begin to calculate something
-    if (!this.isPaused()) {
-      notifyOnNewState(getCurrentState());
-    }
+    // if paused, notify observers only (so they can update the GUI appropriately)
+    notifyOnNewState(getCurrentState(), this.isPaused());
 
     if (checkWinCondition() != null) {
       notifyOnGameOver(generateScoreMap());
@@ -235,7 +233,7 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
   /** Notifies players about the new state, sends a MoveRequest to active player */
   public void afterPause() {
     logger.info("Sending MoveRequest to player {}.", this.activePlayer);
-    notifyOnNewState(getCurrentState());
+    notifyOnNewState(getCurrentState(), false);
     notifyActivePlayer();
   }
 
@@ -293,11 +291,11 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
     }
   }
 
-  protected void notifyOnNewState(IGameState mementoState) {
+  protected void notifyOnNewState(IGameState mementoState, boolean observersOnly) {
     for (IGameListener listener : this.listeners) {
       logger.debug("notifying {} about new game state", listener);
       try {
-        listener.onStateChanged(mementoState);
+        listener.onStateChanged(mementoState, observersOnly);
       } catch (Exception e) {
         logger.error("NewState Notification caused an exception.", e);
       }

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -242,9 +242,10 @@ public class GameRoom implements IGameListener {
    * @param data State Object that derives Object
    */
   @Override
-  public void onStateChanged(IGameState data) {
+  public void onStateChanged(IGameState data, boolean observersOnly) {
     sendStateToObservers(data);
-    sendStateToPlayers(data);
+    if (!observersOnly)
+      sendStateToPlayers(data);
   }
 
 


### PR DESCRIPTION
In case the game is paused, only observers should be notified, so the
GUI can update accordingly without the clients being able to calculate
their moves already

Fixes https://github.com/CAU-Kiel-Tech-Inf/gui/issues/1