### PR TITLE
Feat/getPossibleMoves

### DIFF
--- a/plugin/src/shared/sc/plugin2021/Board.kt
+++ b/plugin/src/shared/sc/plugin2021/Board.kt
@@ -69,6 +69,13 @@ class Board(
             "${it.joinToString(separator = "  ") { it.letter.toString() }}\n"
         }
     }
+
+    companion object {
+        /** @return ob die gegebene Position innerhalb des Spielfelds liegt. */
+        fun contains(position: Coordinates) =
+                position.x >= 0 && position.x < Constants.BOARD_SIZE &&
+                position.y >= 0 && position.y < Constants.BOARD_SIZE
+    }
 }
 
 /** Die Ecken des Spielfelds. */

--- a/plugin/src/shared/sc/plugin2021/Coordinates.kt
+++ b/plugin/src/shared/sc/plugin2021/Coordinates.kt
@@ -26,7 +26,15 @@ data class Coordinates(
     }
     /** Wandelt die [Coordinates] in einen entsprechenden [Vector]. */
     operator fun unaryPlus(): Vector = Vector(x, y)
-    
+
+    /** Gibt ein Set der vier Ecken dieser Koordinaten zurück. */
+    val corners: Set<Coordinates>
+        get() = Vector.diagonals.map { this + it }.toSet()
+
+    /** Gibt ein Set der vier benachbarten Felder dieser Koordinaten zurück. */
+    val neighbors: Set<Coordinates>
+        get() = Vector.cardinals.map { this + it }.toSet()
+
     companion object {
         /** Der Ursprung des Koordinatensystems (0, 0). */
         val origin = Coordinates(0, 0)
@@ -60,4 +68,21 @@ data class Vector(
 
     /** Konvertiert den Vektor zu entsprechendn [Coordinates]. */
     operator fun unaryPlus(): Coordinates = Coordinates(dx, dy)
+
+    companion object {
+        /** Die vier Vektoren in diagonaler Richtung. */
+        val diagonals: Set<Vector> = setOf(
+                Vector(-1, -1),
+                Vector(-1, 1),
+                Vector(1, -1),
+                Vector(1, 1)
+        )
+        /** Die vier Vektoren in kardinaler Richtung. */
+        val cardinals: Set<Vector> = setOf(
+                Vector(-1, 0),
+                Vector(0, -1),
+                Vector(1, 0),
+                Vector(0, 1)
+        )
+    }
 }

--- a/plugin/src/shared/sc/plugin2021/PieceShape.kt
+++ b/plugin/src/shared/sc/plugin2021/PieceShape.kt
@@ -37,7 +37,7 @@ enum class PieceShape(coordinates: Set<Coordinates>) {
     
     /** Ein Vector, der das kleinstmögliche Rechteck beschreibt, dass die vollständige Form umfasst. */
     @XStreamAsAttribute
-    val dimension: Vector = coordinates.area()
+    val dimension: Vector = coordinates.area
     
     /** Die Form als Sammlung aus Vektoren. */
     val asVectors: Set<Vector> by lazy {coordinates.map {it - Coordinates.origin}.toSet()}

--- a/plugin/src/shared/sc/plugin2021/util/Constants.kt
+++ b/plugin/src/shared/sc/plugin2021/util/Constants.kt
@@ -26,6 +26,9 @@ object Constants {
     const val SOFT_TIMEOUT = 2000L
     /** Zeit (in ms), ab dem eine Zuganfrage abgebrochen wird. */
     const val HARD_TIMEOUT = 10000L
+
+    /** Runde, ab der der originale Algorithmus zur Berechnung möglicher Züge verwendet wird. */
+    const val BRUTE_FORCE_ROUND = 26
     
     // Max game length: turns(ROUND_LIMIT * 2) * SOFT_TIMEOUT, one second buffer per round
     /** Zeit (in ms), die ein Spiel höchstens dauern sollte. */

--- a/plugin/src/shared/sc/plugin2021/util/Constants.kt
+++ b/plugin/src/shared/sc/plugin2021/util/Constants.kt
@@ -27,9 +27,6 @@ object Constants {
     /** Zeit (in ms), ab dem eine Zuganfrage abgebrochen wird. */
     const val HARD_TIMEOUT = 10000L
 
-    /** Runde, ab der der originale Algorithmus zur Berechnung möglicher Züge verwendet wird. */
-    const val BRUTE_FORCE_ROUND = 26
-    
     // Max game length: turns(ROUND_LIMIT * 2) * SOFT_TIMEOUT, one second buffer per round
     /** Zeit (in ms), die ein Spiel höchstens dauern sollte. */
     @JvmField

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -219,27 +219,19 @@ object GameRuleLogic {
 
     /** Prüfe, ob das gegebene [Field] bereits an eins mit gleicher Farbe angrenzt. */
     @JvmStatic
-    fun bordersOnColor(board: Board, field: Field): Boolean = listOf(
-            Vector(1, 0),
-            Vector(0, 1),
-            Vector(-1, 0),
-            Vector(0, -1)).any {
-        try {
-            board[field.coordinates + it].content == field.content && !field.isEmpty
-        } catch (e: ArrayIndexOutOfBoundsException) { false }
-    }
+    fun bordersOnColor(board: Board, field: Field): Boolean =
+            field.coordinates.neighbors.any {
+                try { board[it].content == field.content && !field.isEmpty }
+                catch (e: ArrayIndexOutOfBoundsException) { false }
+            }
     
     /** Prüfe, ob das gegebene Feld an die Ecke eines Feldes gleicher Farbe angrenzt. */
     @JvmStatic
-    fun cornersOnColor(board: Board, field: Field): Boolean = listOf(
-            Vector(1, 1),
-            Vector(1, -1),
-            Vector(-1, -1),
-            Vector(-1, 1)).any {
-        try {
-            board[field.coordinates + it].content == field.content && !field.isEmpty
-        } catch (e: ArrayIndexOutOfBoundsException) { false }
-    }
+    fun cornersOnColor(board: Board, field: Field): Boolean =
+            field.coordinates.corners.any {
+                try { board[it].content == field.content && !field.isEmpty }
+                catch (e: ArrayIndexOutOfBoundsException) { false }
+            }
     
     /** Prüfe, ob die gegebene Position eine Ecke des Spielfelds ist. */
     @JvmStatic

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -313,36 +313,35 @@ object GameRuleLogic {
     private fun streamAllMovesSmartly(gameState: GameState) = sequence<SetMove> {
         val validFields: Set<Coordinates> = getValidFields(gameState.board, gameState.currentColor)
 
-        logger.debug("$validFields")
-
         for (field in validFields)
             for (shape in gameState.undeployedPieceShapes(gameState.currentColor))
-                for (variant in shape.variants.filter { it.key.contains(field) })
+                for (variant in shape.variants)
                     for (x in field.x - variant.key.area().dx..field.x)
-                        for (y in field.y - variant.key.area().dy..field.y) {
-                            val move = SetMove(Piece(gameState.currentColor, shape, variant.value.first, variant.value.second, Coordinates(x, y)))
-                            logger.debug("$move is valid: ${isValidSetMove(gameState, move)}")
+                        for (y in field.y - variant.key.area().dy..field.y)
                             yield(SetMove(Piece(gameState.currentColor, shape, variant.value.first, variant.value.second, Coordinates(x, y))))
-                        }
     }.filter { isValidSetMove(gameState, it) }
 
     @JvmStatic
-    private fun getValidFields(board: Board, color: Color): Set<Coordinates> =
-            getColoredFields(board, color, Corner.values().map { it.position }.filter {
-                board[it].content == +color }.toMutableSet()
-            ).flatMap { it.corners }.filter {
-                Board.contains(it) && board[it].isEmpty && it.corners.none {
-                    Board.contains(it) && board[it].content == +color
-                }
-            }.toSet()
+    private fun getValidFields(board: Board, color: Color): Set<Coordinates> {
+        val coloredFields = getColoredFields(board, color, Corner.values().map { it.position }.filter {
+            board[it].content == +color
+        }.toMutableSet())
+
+        val validFields = coloredFields.flatMap { it.corners }.filter {
+            Board.contains(it) && board[it].isEmpty && it.neighbors.none {
+                Board.contains(it) && board[it].content == +color
+            }
+        }.toSet()
+
+        return validFields
+    }
 
     @JvmStatic
     private fun getColoredFields(board: Board, color: Color, coloredFields: MutableSet<Coordinates>): Set<Coordinates> {
-        logger.debug("$coloredFields")
         val copy = coloredFields.toSet()
         coloredFields.addAll(coloredFields.flatMap { it.corners + it.neighbors }.filter {
             Board.contains(it) && board[it].content == +color
         })
-        return if (coloredFields == copy) coloredFields else getColoredFields(board, color, coloredFields)
+        return if (coloredFields == copy) copy else getColoredFields(board, color, coloredFields)
     }
 }

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -275,10 +275,11 @@ object GameRuleLogic {
     
     /** Stream all possible moves regardless of whether it's the first turn. */
     @JvmStatic
-    private fun streamAllPossibleMoves(gameState: GameState): Sequence<SetMove> = sequenceOf(
+    private fun streamAllPossibleMoves(gameState: GameState): Sequence<SetMove> = sequence {
         gameState.undeployedPieceShapes(gameState.currentColor).map {
-            streamPossibleMovesForShape(gameState, it)
-        }).flatten().flatten()
+            yieldAll(streamPossibleMovesForShape(gameState, it))
+        }
+    }
 
     /** Gib eine Sammlung aller möglichen [SetMove]s für die gegebene [PieceShape] zurück. */
     @JvmStatic

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -269,7 +269,11 @@ object GameRuleLogic {
             if (isFirstMove(gameState))
                 streamPossibleStartMoves(gameState)
             else
-                streamAllPossibleMoves(gameState)
+                if (gameState.round < Constants.BRUTE_FORCE_ROUND)
+                    streamAllMovesSmartly(gameState)
+                else
+                    streamAllPossibleMoves(gameState)
+
     
     /** Stream all possible moves regardless of whether it's the first turn. */
     @JvmStatic

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -160,8 +160,6 @@ object GameRuleLogic {
     /** Prüfe, ob der gegebene [SetMove] auf dem [Board] platziert werden kann. */
     @JvmStatic
     fun validateSetMove(board: Board, move: SetMove, throws: Boolean = false): MoveMistake? {
-        // throw IndexOutOfBounds if the initial position only is out of bounds
-        board[move.piece.position]
         move.piece.coordinates.forEach {
             try {
                 board[it]

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -297,4 +297,30 @@ object GameRuleLogic {
             }
         }
     }.filter { isValidSetMove(gameState, it) }
+
+    @JvmStatic
+    fun getPossibleMovesSmartly(gameState: GameState) =
+            streamPossibleMovesSmartly(gameState).toSet()
+
+    @JvmStatic
+    private fun streamPossibleMovesSmartly(gameState: GameState) =
+            if (isFirstMove(gameState))
+                streamPossibleStartMoves(gameState)
+            else
+                streamAllMovesSmartly(gameState)
+
+    @JvmStatic
+    private fun streamAllMovesSmartly(gameState: GameState) = sequence<SetMove> {
+        val validFields: Set<Coordinates> = getValidFields(gameState.board, gameState.currentColor)
+
+        for (field in validFields)
+            for (shape in gameState.undeployedPieceShapes(gameState.currentColor))
+                for (variant in shape.variants.filter { it.key.contains(field) })
+                    yield(SetMove(Piece(gameState.currentColor, shape, variant.value.first, variant.value.second, field)))
+    }
+
+    @JvmStatic
+    private fun getValidFields(board: Board, color: Color): Set<Coordinates> {
+        return emptySet()
+    }
 }

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -258,11 +258,6 @@ object GameRuleLogic {
                     .filter{ it.size == 5 && it != PieceShape.PENTO_X }
                     .random()
     
-    /** Gib eine Sammlung an möglichen [SetMove]s zurück. */
-    @JvmStatic
-    fun getPossibleMoves(gameState: GameState) =
-            streamPossibleMoves(gameState).toSet()
-    
     /** Entferne alle Farben, die keine Steine mehr auf dem Feld platzieren können. */
     @JvmStatic
     fun removeInvalidColors(gameState: GameState) {
@@ -272,7 +267,12 @@ object GameRuleLogic {
             removeInvalidColors(gameState)
         }
     }
-    
+
+    /** Gib eine Sammlung an möglichen [SetMove]s zurück. */
+    @JvmStatic
+    fun getPossibleMoves(gameState: GameState) =
+            streamPossibleMoves(gameState).toSet()
+
     /** Gib Eine Sequenz an möglichen [SetMove]s zurück. */
     @JvmStatic
     fun streamPossibleMoves(gameState: GameState) =
@@ -286,12 +286,12 @@ object GameRuleLogic {
     private fun streamAllPossibleMoves(gameState: GameState) = sequence<SetMove> {
         val color = gameState.currentColor
         gameState.undeployedPieceShapes(color).map {
-            val area = it.coordinates.area()
-            for (y in 0 until Constants.BOARD_SIZE - area.dy)
-                for (x in 0 until Constants.BOARD_SIZE - area.dx)
-                    for (variant in it.variants) {
+            for (variant in it.variants) {
+                val area = variant.key.area()
+                for (y in 0 until Constants.BOARD_SIZE - area.dy)
+                    for (x in 0 until Constants.BOARD_SIZE - area.dx)
                         yield(SetMove(Piece(color, it, variant.key, Coordinates(x, y))))
-                    }
+            }
         }
     }.filter { isValidSetMove(gameState, it) }
     

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -290,7 +290,7 @@ object GameRuleLogic {
     fun streamPossibleMovesForShape(gameState: GameState, shape: PieceShape) = sequence<SetMove> {
         val color = gameState.currentColor
         for (variant in shape.variants) {
-            val area = variant.key.area()
+            val area = variant.key.area
             for (y in 0 until Constants.BOARD_SIZE - area.dy) {
                 for (x in 0 until Constants.BOARD_SIZE - area.dx) {
                     yield(SetMove(Piece(color, shape, variant.key, Coordinates(x, y))))
@@ -305,7 +305,7 @@ object GameRuleLogic {
         val kind = gameState.startPiece
         for (variant in kind.variants) {
             for (corner in Corner.values()) {
-                yield(SetMove(Piece(gameState.currentColor, kind, variant.key, corner.align(variant.key.area()))))
+                yield(SetMove(Piece(gameState.currentColor, kind, variant.key, corner.align(variant.key.area))))
             }
         }
     }.filter { isValidSetMove(gameState, it) }
@@ -328,8 +328,8 @@ object GameRuleLogic {
         for (field in validFields)
             for (shape in gameState.undeployedPieceShapes(gameState.currentColor))
                 for (variant in shape.variants)
-                    for (x in field.x - variant.key.area().dx..field.x)
-                        for (y in field.y - variant.key.area().dy..field.y)
+                    for (x in field.x - variant.key.area.dx..field.x)
+                        for (y in field.y - variant.key.area.dy..field.y)
                             yield(SetMove(Piece(gameState.currentColor, shape, variant.value.first, variant.value.second, Coordinates(x, y))))
     }.filter { isValidSetMove(gameState, it) }
 

--- a/plugin/src/shared/sc/plugin2021/util/SetHelpers.kt
+++ b/plugin/src/shared/sc/plugin2021/util/SetHelpers.kt
@@ -63,27 +63,28 @@ fun Set<Coordinates>.align(): Set<Coordinates> {
  * Berechne die Ausmaße des kleinstmöglichen Rechtecks, welches alle Koordinaten umfasst.
  * @return ein Vector von der linken oberen Ecke zur rechten unteren Ecke
  */
-fun Set<Coordinates>.area(): Vector {
-    var dx = 0
-    var dy = 0
-    forEach {
-        dx = kotlin.math.max(it.x, dx)
-        dy = kotlin.math.max(it.y, dy)
+val Set<Coordinates>.area: Vector
+    get() {
+        var dx = 0
+        var dy = 0
+        forEach {
+            dx = kotlin.math.max(it.x, dx)
+            dy = kotlin.math.max(it.y, dy)
+        }
+        return Vector(dx, dy)
     }
-    return Vector(dx, dy)
-}
 
 /**
  * Gebe die Form der Koordinaten zur Konsole aus.
  * @param dimension die Ausmaße der entstehenden Graphik
  */
-fun Set<Coordinates>.print(dimension: Vector = area()) {
+fun Set<Coordinates>.print(dimension: Vector = area) {
     printShapes(this, dimension = dimension)
 }
 
 /** Gebe die gegebenen Formen zur Konsole aus, alle in gegebenen Ausmaßen. */
 fun printShapes(vararg shapes: Set<Coordinates>, dimension: Vector = Vector(4, 5)) {
-    if (shapes.any{it.area() < dimension})
+    if (shapes.any{ it.area < dimension })
         throw IndexOutOfBoundsException("The largest shape has to fit in the given dimension")
         
     val width = shapes.size * (dimension.dx + 1)

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -142,4 +142,17 @@ class GameRuleLogicTest: StringSpec({
     "All possible moves get calculated" {
         // TODO: set up a mid-game state so that the list of possible moves is non-trivial
     }
+    "All possible moves get calculated efficiently" {
+        val game = Game()
+        val state = game.gameState
+        game.onPlayerJoined().color shouldBe Team.ONE
+        game.onPlayerJoined().color shouldBe Team.TWO
+        game.start()
+
+        while (!game.checkGameOver()) {
+                val moves = GameRuleLogic.getPossibleMoves(state)
+                moves shouldNotBe emptySet<SetMove>()
+                game.onAction(state.currentPlayer, moves.random())
+        }
+    }
 })

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -1,8 +1,6 @@
 package sc.plugin2021
 
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -142,20 +140,5 @@ class GameRuleLogicTest: StringSpec({
     }
     "All possible moves get calculated" {
         // TODO: set up a mid-game state so that the list of possible moves is non-trivial
-    }
-    "All possible moves get calculated efficiently" {
-        val game = Game()
-        val state = game.gameState
-        game.onPlayerJoined().color shouldBe Team.ONE
-        game.onPlayerJoined().color shouldBe Team.TWO
-        game.start()
-
-        while (!game.checkGameOver()) {
-            val SHOULD = GameRuleLogic.getPossibleMoves(state)
-
-            GameRuleLogic.getPossibleMovesSmartly(state) shouldBe SHOULD
-
-            game.onAction(state.currentPlayer, SHOULD.random())
-        }
     }
 })

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -150,9 +150,12 @@ class GameRuleLogicTest: StringSpec({
         game.start()
 
         while (!game.checkGameOver()) {
-                val moves = GameRuleLogic.getPossibleMoves(state)
-                moves shouldNotBe emptySet<SetMove>()
-                game.onAction(state.currentPlayer, moves.random())
+            val SHOULD = GameRuleLogic.getPossibleMoves(state)
+            val IS = GameRuleLogic.getPossibleMovesSmartly(state)
+
+            IS shouldBe SHOULD
+
+            game.onAction(state.currentPlayer, SHOULD.random())
         }
     }
 })

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -153,9 +153,7 @@ class GameRuleLogicTest: StringSpec({
         while (!game.checkGameOver()) {
             val SHOULD = GameRuleLogic.getPossibleMoves(state)
 
-            shouldNotThrow<ArrayIndexOutOfBoundsException> {
-                GameRuleLogic.getPossibleMovesSmartly(state) shouldBe SHOULD
-            }
+            GameRuleLogic.getPossibleMovesSmartly(state) shouldBe SHOULD
 
             game.onAction(state.currentPlayer, SHOULD.random())
         }

--- a/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameRuleLogicTest.kt
@@ -1,5 +1,6 @@
 package sc.plugin2021
 
+import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.core.spec.style.StringSpec
@@ -151,9 +152,10 @@ class GameRuleLogicTest: StringSpec({
 
         while (!game.checkGameOver()) {
             val SHOULD = GameRuleLogic.getPossibleMoves(state)
-            val IS = GameRuleLogic.getPossibleMovesSmartly(state)
 
-            IS shouldBe SHOULD
+            shouldNotThrow<ArrayIndexOutOfBoundsException> {
+                GameRuleLogic.getPossibleMovesSmartly(state) shouldBe SHOULD
+            }
 
             game.onAction(state.currentPlayer, SHOULD.random())
         }


### PR DESCRIPTION
`getPossibleMoves` is pretty inefficient, thus this PR introduces an algorithm more efficient when the board is still empty.

Also, this'll add a new function, `getPossibleMovesForShape`, similarly to how the ruby client currently calculates it, to be able to calculate all possible moves for certain shapes only