### PR TITLE
Fix/getPossibleMovesForShapes

### DIFF
--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -42,7 +42,7 @@ class GameState @JvmOverloads constructor(
     override val board: Board = Board()
     
     /** Gib eine Liste aller nicht gesetzter Steine der [Color] zurück. */
-    fun undeployedPieceShapes(color: Color): MutableSet<PieceShape> = when (color) {
+    fun undeployedPieceShapes(color: Color = currentColor): MutableSet<PieceShape> = when (color) {
         Color.BLUE -> blueShapes
         Color.YELLOW -> yellowShapes
         Color.RED -> redShapes

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -301,7 +301,7 @@ object GameRuleLogic {
             gameState: GameState,
             shape: PieceShape,
             validFields: Set<Coordinates> = getValidFields(gameState.board, gameState.currentColor)
-    ) = sequence<SetMove> {
+    ) = if (isFirstMove(gameState)) streamPossibleStartMoves(gameState) else sequence<SetMove> {
         for (field in validFields) {
             for (variant in shape.variants) {
                 val area = variant.key.area

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -239,7 +239,7 @@ object GameRuleLogic {
     /** Gib zurück, ob sich der [GameState] noch in der ersten Runde befindet. */
     @JvmStatic
     fun isFirstMove(gameState: GameState) =
-            gameState.undeployedPieceShapes(gameState.currentColor).size == Constants.TOTAL_PIECE_SHAPES
+            gameState.undeployedPieceShapes().size == Constants.TOTAL_PIECE_SHAPES
     
     /** Return a random pentomino which is not the `x` one (Used to get a valid starting piece). */
     @JvmStatic
@@ -286,7 +286,7 @@ object GameRuleLogic {
     fun streamAllPossibleMoves(gameState: GameState) = sequence<SetMove> {
         val validFields: Set<Coordinates> = getValidFields(gameState.board, gameState.currentColor)
 
-        for (shape in gameState.undeployedPieceShapes(gameState.currentColor))
+        for (shape in gameState.undeployedPieceShapes())
             yieldAll(streamPossibleMovesForShape(gameState, shape, validFields))
     }
 


### PR DESCRIPTION
`getPossibleMovesForShapes` failed on first round, because it wasn't designed to be called there.
But since it's publicly available this lead to failures, which this PR fixes.

It also includes a small refactor regarding the accessor of `undeployedPieceShapes` which is too small to create an independent PR for.

This can be rebase merged as-is