### PR TITLE
feat(plugin): make every round four turns long

### DIFF
--- a/plugin/src/server/sc/plugin2021/Game.kt
+++ b/plugin/src/server/sc/plugin2021/Game.kt
@@ -71,9 +71,7 @@ class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
      * the player with the highest cumulative score of its colors
      */
     override fun checkWinCondition(): WinCondition? {
-        if (gameState.orderedColors.any {
-            GameRuleLogic.getPossibleMoves(gameState).isNotEmpty()
-        }) return null
+        if (!checkGameOver()) return null
 
         val scores: Map<Team, Int> = Team.values().map {
             it to gameState.getPointsForPlayer(it)
@@ -166,11 +164,11 @@ class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
     override fun getCurrentState(): IGameState = gameState
     
     val isGameOver: Boolean
-        get() = gameState.orderedColors.isEmpty() || round > Constants.ROUND_LIMIT
+        get() = gameState.validColors.isEmpty() || round > Constants.ROUND_LIMIT
 
     fun checkGameOver(): Boolean {
         if (round > Constants.ROUND_LIMIT) {
-            gameState.orderedColors.clear()
+            gameState.validColors.clear()
         }
         GameRuleLogic.removeInvalidColors(gameState)
         return isGameOver

--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -26,9 +26,6 @@ class GameState @JvmOverloads constructor(
         override var second: Player = Player(Team.TWO),
         /** Der zuletzt gespielte Zug. */
         override var lastMove: Move? = null,
-        startTurn: Int = 0,
-        /** Die Farbe, die anfängt. */
-        val startColor: Color = Color.BLUE,
         /** Der Spielstein, der in der ersten Runde gesetzt werden muss. */
         @XStreamAsAttribute val startPiece: PieceShape = GameRuleLogic.getRandomPentomino()
 ): TwoPlayerGameState<Player>(Team.ONE) {
@@ -67,44 +64,33 @@ class GameState @JvmOverloads constructor(
         get() = getPlayer(currentTeam)!!
     
     /** Eine Liste aller Farben, die momentan im Spiel sind. */
-    @XStreamAsAttribute
-    val orderedColors: MutableList<Color> =
-            Constants.COLORS.downTo(2).fold(mutableListOf(startColor), { acc, _ -> acc.add(acc.last().next); acc })
-    
-    @XStreamAsAttribute
-    private var currentColorIndex: Int = startTurn % orderedColors.size
-    
+    val orderedColors: List<Color>
+        get() = Color.values().toList()
+
+    @XStreamOmitField
+    internal val validColors: MutableSet<Color> = Color.values().toMutableSet()
+
     /** Die Farbe, die am Zug ist. */
     val currentColor: Color
-        get() = if (orderedColors.isEmpty()) {
-            throw IndexOutOfBoundsException("Trying to access currentColor while there are no colors in the game!")
-        } else {
-            orderedColors[currentColorIndex]
-        }
-    
+        get() = orderedColors[turn % Constants.COLORS]
+
     /** Die Anzahl an bereits getätigten Zügen. */
     @XStreamAsAttribute
-    override var turn: Int = startTurn
+    override var turn: Int = 0
         set(value) {
-            advance(value - field)
+            if (value < 0) throw IndexOutOfBoundsException("Can't go back in value (request was $turn to $value)")
             field = value
         }
     
     /** Die Rundenzahl. */
     @XStreamAsAttribute
-    override var round: Int = 1 + startTurn / orderedColors.size
-    
-    private fun advance(turns: Int) {
-        if (turns < 0) throw IndexOutOfBoundsException("Can't go back in turns (request was $turns): Expected value bigger than $turn")
-        
-        if (orderedColors.isEmpty())
-            throw GameLogicException("Game has already ended - can't proceed to next turn")
-        
-        val roundIncrementHelper = currentColorIndex + turns
-        currentColorIndex = roundIncrementHelper % orderedColors.size
-        round += (roundIncrementHelper - currentColorIndex) / orderedColors.size
-    }
-    
+    override var round: Int = 1
+        private set
+        get() {
+            field = 1 + turn / orderedColors.size
+            return field
+        }
+
     /**
      * Versuche, zum nächsten Zug überzugehen.
      * Schlage fehl, wenn das Spiel bereits zu ende ist.
@@ -116,43 +102,41 @@ class GameState @JvmOverloads constructor(
     } catch (e: Exception) {
         false
     }
-    
+
     fun addPlayer(player: Player) {
         when (player.color) {
             Team.ONE -> first = player
             Team.TWO -> second = player
         }
     }
-    
+
     /** Berechne die Punkteanzahl für das gegebene Team. */
     override fun getPointsForPlayer(team: ITeam): Int =
             (team as Team).colors.map { getPointsForColor(it) }.sum()
-    
+
     private fun getPointsForColor(color: Color): Int {
         val pieces = undeployedPieceShapes(color)
         val lastMono = lastMoveMono[color] ?: false
         return GameRuleLogic.getPointsFromUndeployed(pieces, lastMono)
     }
-    
+
     /**
      * Entferne die Farbe, die momentan am Zug ist.
      * Die resultierende aktive Farbe wird dann die des letzten Zuges sein.
      *
      * Diese Funktion wird von der [GameRuleLogic] benötigt und sollte nie so aufgerufen werden.
      */
-    internal fun removeActiveColor() {
-        logger.info("Removing $currentColor from the game")
-        orderedColors.removeAt(currentColorIndex)
-        if (orderedColors.isNotEmpty())
-            currentColorIndex = (currentColorIndex + orderedColors.size) % orderedColors.size
-        logger.debug("Remaining Colors: $orderedColors")
+    internal fun remove(color: Color = currentColor) {
+        logger.info("Removing $color from the game")
+        validColors.remove(color)
+        logger.debug("Remaining Colors: $validColors")
     }
-    
+
     override fun toString(): String =
             if (orderedColors.isNotEmpty())
                 "GameState $round/$turn -> $currentColor ${if (GameRuleLogic.isFirstMove(this)) "(Start Piece: $startPiece)" else ""}"
             else "GameState finished at $round/$turn"
-    
+
     override fun equals(other: Any?): Boolean {
         return !(this === other) &&
                other is GameState &&
@@ -162,23 +146,15 @@ class GameState @JvmOverloads constructor(
                turn == other.turn &&
                currentTeam == other.currentTeam
     }
-    
+
     override fun hashCode(): Int {
         var result = first.hashCode()
         result = 31 * result + second.hashCode()
         result = 31 * result + (lastMove?.hashCode() ?: 0)
-        result = 31 * result + startColor.hashCode()
         result = 31 * result + startPiece.hashCode()
         result = 31 * result + board.hashCode()
-        result = 31 * result + blueShapes.hashCode()
-        result = 31 * result + yellowShapes.hashCode()
-        result = 31 * result + redShapes.hashCode()
-        result = 31 * result + greenShapes.hashCode()
         result = 31 * result + lastMoveMono.hashCode()
-        result = 31 * result + orderedColors.hashCode()
-        result = 31 * result + currentColorIndex
         result = 31 * result + turn
-        result = 31 * result + round
         return result
     }
 }

--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -70,6 +70,10 @@ class GameState @JvmOverloads constructor(
     @XStreamOmitField
     internal val validColors: MutableSet<Color> = Color.values().toMutableSet()
 
+    /** Prüfe, ob die gegebene Farbe noch im Spiel ist. */
+    fun isValid(color: Color = currentColor): Boolean =
+            validColors.contains(color)
+
     /** Die Farbe, die am Zug ist. */
     val currentColor: Color
         get() = orderedColors[turn % Constants.COLORS]

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -251,9 +251,10 @@ object GameRuleLogic {
     /** Entferne alle Farben, die keine Steine mehr auf dem Feld platzieren können. */
     @JvmStatic
     fun removeInvalidColors(gameState: GameState) {
-        if (gameState.orderedColors.isEmpty()) return
+        if (gameState.validColors.isEmpty()) return
         if (streamPossibleMoves(gameState).none { isValidSetMove(gameState, it) }) {
-            gameState.removeActiveColor()
+            gameState.remove()
+            gameState.turn++
             removeInvalidColors(gameState)
         }
     }

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -116,7 +116,9 @@ object GameRuleLogic {
         if (gameState.undeployedPieceShapes(move.color).isEmpty())
             gameState.lastMoveMono += move.color to (move.piece.kind == PieceShape.MONO)
 
-        gameState.tryAdvance()
+        do {
+            gameState.tryAdvance()
+        } while (!gameState.validColors.contains(gameState.currentColor))
     }
 
     /**

--- a/plugin/src/test/sc/plugin2021/GameTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import sc.api.plugins.exceptions.GameLogicException
 import io.kotest.matchers.shouldNotBe
 import sc.plugin2021.util.Constants
 import sc.plugin2021.util.GameRuleLogic
@@ -40,14 +41,14 @@ class GameTest: WordSpec({
                         break
                     }
                 }
-                
+
                 val scores = game.playerScores
                 val score1 = game.getScoreFor(one)
                 val score2 = game.getScoreFor(two)
                 scores shouldBe listOf(score1, score2)
                 score1.cause shouldBe ScoreCause.REGULAR
                 score2.cause shouldBe ScoreCause.REGULAR
-                
+
                 val points1 = BigDecimal(state.getPointsForPlayer(one.color))
                 val points2 = BigDecimal(state.getPointsForPlayer(two.color))
                 when {
@@ -68,16 +69,16 @@ class GameTest: WordSpec({
             "end in a draw when everyone skips" {
                 for (s in 0 until 4)
                     game.onAction(state.currentPlayer, GameRuleLogic.streamPossibleMoves(state).first())
-                
+
                 shouldNotThrowAny {
                     while (!game.checkGameOver()) {
                         game.onAction(state.currentPlayer, SkipMove(state.currentColor))
                     }
                 }
-                shouldThrow<java.lang.IndexOutOfBoundsException> {
+                shouldThrow<GameLogicException> {
                     game.onAction(state.currentPlayer, SkipMove(state.currentColor))
                 }
-                
+
                 game.playerScores shouldContainExactly List(2) {
                     PlayerScore(ScoreCause.REGULAR, "", Constants.DRAW_SCORE, 10)
                 }

--- a/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
+++ b/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
@@ -42,7 +42,7 @@ class ConverterTest: WordSpec({
         "serialised" Should {
             "be encoded properly" {
                 state shouldSerializeTo """
-                    <state currentColorIndex="0" turn="0" round="1" startPiece="PENTO_L">
+                    <state turn="0" round="1" startPiece="PENTO_L">
                       <startTeam class="team">ONE</startTeam>
                       <board>
                         <field x="0" y="0" content="RED"/>
@@ -143,19 +143,12 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_Y</shape>
                       </greenShapes>
                       <lastMoveMono class="linked-hash-map"/>
-                      <orderedColors>
-                        <color>BLUE</color>
-                        <color>YELLOW</color>
-                        <color>RED</color>
-                        <color>GREEN</color>
-                      </orderedColors>
                       <first displayName="">
                         <color class="team">ONE</color>
                       </first>
                       <second displayName="">
                         <color class="team">TWO</color>
                       </second>
-                      <startColor>BLUE</startColor>
                     </state>""".trimIndent()
             }
         }

--- a/sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
+++ b/sdk/src/server-api/sc/framework/plugins/RoundBasedGameInstance.java
@@ -165,14 +165,15 @@ public abstract class RoundBasedGameInstance<P extends Player> implements IGameI
   }
 
   protected final void next(P nextPlayer, boolean firstTurn) {
-    logger.debug("next round ({}) for player {}", getRound(), nextPlayer);
-    if (!firstTurn) {
-      turn++;
+    if (nextPlayer != null) {
+      logger.debug("next round ({}) for player {}", getRound(), nextPlayer);
+      if (!firstTurn) {
+        turn++;
+      }
+      this.activePlayer = nextPlayer;
+      // if paused, notify observers only (so they can update the GUI appropriately)
+      notifyOnNewState(getCurrentState(), this.isPaused());
     }
-    this.activePlayer = nextPlayer;
-    // if paused, notify observers only (so they can update the GUI appropriately)
-    notifyOnNewState(getCurrentState(), this.isPaused());
-
     if (checkWinCondition() != null) {
       notifyOnGameOver(generateScoreMap());
     } else {


### PR DESCRIPTION
There are inconsistencies and issues due to the fact that the number of turns in a round depended on the number of colors still in the game.
Thus, with this, every round consists of exactly four turns