### PR TITLE
Make GameRuleLogic methods public

### DIFF
--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -321,9 +321,9 @@ object GameRuleLogic {
         }.filter { isValidSetMove(gameState, it) }
     }
 
-    /** @return all [Coordinates] the currently active [Color] can place [Piece]s upon. */
+    /** @return alle [Coordinates], auf die die aktuelle [Color] Steine platzieren könnte. */
     @JvmStatic
-    private fun getValidFields(board: Board, color: Color): Set<Coordinates> {
+    fun getValidFields(board: Board, color: Color): Set<Coordinates> {
         val coloredFields = getColoredFields(board, color, Corner.values().map { it.position }.filter {
             board[it].content == +color
         }.toMutableSet())

--- a/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
+++ b/plugin/src/shared/sc/plugin2021/util/GameRuleLogic.kt
@@ -323,27 +323,26 @@ object GameRuleLogic {
 
     /** @return alle [Coordinates], auf die die aktuelle [Color] Steine platzieren könnte. */
     @JvmStatic
-    fun getValidFields(board: Board, color: Color): Set<Coordinates> {
-        val coloredFields = getColoredFields(board, color, Corner.values().map { it.position }.filter {
-            board[it].content == +color
-        }.toMutableSet())
+    fun getValidFields(board: Board, color: Color): Set<Coordinates> =
+            getColoredFields(board, color).flatMap { it.corners }.filter {
+                Board.contains(it) && board[it].isEmpty && it.neighbors.none {
+                    Board.contains(it) && board[it].content == +color
+                }
+            }.toSet()
 
-        val validFields = coloredFields.flatMap { it.corners }.filter {
-            Board.contains(it) && board[it].isEmpty && it.neighbors.none {
-                Board.contains(it) && board[it].content == +color
-            }
-        }.toSet()
-
-        return validFields
-    }
-
-    /** @return all [Coordinates] belonging to the currently active [Color]. */
+    /** @return alle [Coordinates], deren Position auf dem [Board] die gegebene [Color] hat. */
     @JvmStatic
-    private fun getColoredFields(board: Board, color: Color, coloredFields: MutableSet<Coordinates>): Set<Coordinates> {
+    fun getColoredFields(board: Board, color: Color): Set<Coordinates> =
+            getColoredFieldsRecursively(board, color, Corner.values().map { it.position }.filter {
+                board[it].content == +color
+            }.toMutableSet())
+
+    /** Recursive function filling [coloredFields] with all [Coordinates] on the [Board] with the given [Color]. */
+    private fun getColoredFieldsRecursively(board: Board, color: Color, coloredFields: MutableSet<Coordinates>): Set<Coordinates> {
         val copy = coloredFields.toSet()
         coloredFields.addAll(coloredFields.flatMap { it.corners + it.neighbors }.filter {
             Board.contains(it) && board[it].content == +color
         })
-        return if (coloredFields == copy) copy else getColoredFields(board, color, coloredFields)
+        return if (coloredFields == copy) copy else getColoredFieldsRecursively(board, color, coloredFields)
     }
 }


### PR DESCRIPTION
Makes the methods `getValidFields` and `getColoredFields` public.
They were meant to be helper functions only but may help clients to analyse a given board