### PR TITLE
feat(plugin): serialise validColors

### DIFF
--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -67,7 +67,6 @@ class GameState @JvmOverloads constructor(
     val orderedColors: List<Color>
         get() = Color.values().toList()
 
-    @XStreamOmitField
     internal val validColors: MutableSet<Color> = Color.values().toMutableSet()
 
     /** Prüfe, ob die gegebene Farbe noch im Spiel ist. */

--- a/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
+++ b/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
@@ -143,6 +143,12 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_Y</shape>
                       </greenShapes>
                       <lastMoveMono class="linked-hash-map"/>
+                      <validColors class="linked-hash-set">
+                        <color>BLUE</color>
+                        <color>YELLOW</color>
+                        <color>RED</color>
+                        <color>GREEN</color>
+                      </validColors>
                       <first displayName="">
                         <color class="team">ONE</color>
                       </first>


### PR DESCRIPTION
Players may need to know which colors are currently still in play.