### PR TITLE
Remove turn tracking and XStream annotations from RoundBasedGameInstance

### DIFF
--- a/plugin/src/server/sc/plugin2021/Game.kt
+++ b/plugin/src/server/sc/plugin2021/Game.kt
@@ -1,6 +1,5 @@
 package sc.plugin2021
 
-import com.thoughtworks.xstream.annotations.XStreamAlias
 import org.slf4j.LoggerFactory
 import sc.api.plugins.IGameState
 import sc.framework.plugins.ActionTimeout
@@ -13,7 +12,6 @@ import sc.plugin2021.util.WinReason
 import sc.protocol.responses.ProtocolMessage
 import sc.shared.*
 
-@XStreamAlias(value = "game")
 class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
     companion object {
         val logger = LoggerFactory.getLogger(Game::class.java)
@@ -65,10 +63,6 @@ class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
 
     override val players: MutableList<Player>
         get() = super.players
-    
-
-    override val round: Int
-        get() = gameState.round
     
     /**
      * Checks whether and why the game is over.
@@ -169,15 +163,16 @@ class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
     override val currentState: IGameState
         get() = gameState
 
-    val isGameOver: Boolean
-        get() = !gameState.hasValidColors() || round > Constants.ROUND_LIMIT
+    private val isGameOver: Boolean
+        get() = !gameState.hasValidColors() || gameState.round > Constants.ROUND_LIMIT
 
     fun checkGameOver(): Boolean {
-        logger.debug("Round: $round > ${Constants.ROUND_LIMIT}")
-        if (round > Constants.ROUND_LIMIT) {
+        logger.debug("Round: ${gameState.round} > ${Constants.ROUND_LIMIT}")
+        if (gameState.round > Constants.ROUND_LIMIT) {
             gameState.clearValidColors()
+        } else {
+            GameRuleLogic.removeInvalidColors(gameState)
         }
-        GameRuleLogic.removeInvalidColors(gameState)
         return isGameOver
     }
 }

--- a/plugin/src/server/sc/plugin2021/Game.kt
+++ b/plugin/src/server/sc/plugin2021/Game.kt
@@ -2,9 +2,9 @@ package sc.plugin2021
 
 import org.slf4j.LoggerFactory
 import sc.api.plugins.IGameState
+import sc.framework.plugins.AbstractGame
 import sc.framework.plugins.ActionTimeout
 import sc.framework.plugins.Player
-import sc.framework.plugins.RoundBasedGameInstance
 import sc.plugin2021.util.Constants
 import sc.plugin2021.util.GameRuleLogic
 import sc.plugin2021.util.MoveMistake
@@ -12,7 +12,7 @@ import sc.plugin2021.util.WinReason
 import sc.protocol.responses.ProtocolMessage
 import sc.shared.*
 
-class Game: RoundBasedGameInstance<Player>(GamePlugin.PLUGIN_UUID) {
+class Game: AbstractGame<Player>(GamePlugin.PLUGIN_UUID) {
     companion object {
         val logger = LoggerFactory.getLogger(Game::class.java)
     }

--- a/plugin/src/test/sc/plugin2021/GameTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameTest.kt
@@ -73,7 +73,7 @@ class GameTest: WordSpec({
 
                 shouldNotThrowAny {
                     while (!game.checkGameOver()) {
-                        logger.debug("is Game Over? ${game.isGameOver} - ${state.round} > ${Constants.ROUND_LIMIT}")
+                        logger.debug("is Game Over? ${game.checkGameOver()} - ${state.round} > ${Constants.ROUND_LIMIT}")
                         game.onAction(state.currentPlayer, SkipMove(state.currentColor))
                     }
                 }

--- a/sdk/src/server-api/sc/framework/plugins/AbstractGame.kt
+++ b/sdk/src/server-api/sc/framework/plugins/AbstractGame.kt
@@ -27,16 +27,7 @@ abstract class AbstractGame<P : Player>(override val pluginUUID: String) : IGame
     
     private var moveRequestTimeout: ActionTimeout? = null
     
-    var paused = false
-        private set
-    
-    val isPaused: Boolean
-        get() = paused
-    
-    /** Pause or unpause game. */
-    fun setPauseMode(pause: Boolean) {
-        paused = pause
-    }
+    var isPaused = false
     
     fun afterPause() {
         logger.info("Sending MoveRequest to player $activePlayer")

--- a/sdk/src/server-api/sc/framework/plugins/AbstractGame.kt
+++ b/sdk/src/server-api/sc/framework/plugins/AbstractGame.kt
@@ -13,9 +13,9 @@ import sc.shared.ScoreCause
 import sc.shared.WinCondition
 import java.util.*
 
-abstract class RoundBasedGameInstance<P : Player>(override val pluginUUID: String) : IGameInstance {
+abstract class AbstractGame<P : Player>(override val pluginUUID: String) : IGameInstance {
     companion object {
-        val logger = LoggerFactory.getLogger(RoundBasedGameInstance::class.java)
+        val logger = LoggerFactory.getLogger(AbstractGame::class.java)
     }
     
     override val players = mutableListOf<P>()

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -501,7 +501,7 @@ public class GameRoom implements IGameListener {
     this.pauseRequested = pause;
     AbstractGame<Player> pausableGame = (AbstractGame<Player>) this.game;
     // pause game after current turn has finished
-    pausableGame.setPauseMode(pause);
+    pausableGame.setPaused(pause);
 
     // continue execution
     if (!isPauseRequested()) {
@@ -579,7 +579,7 @@ public class GameRoom implements IGameListener {
     this.status = status;
   }
 
-  /** Remove a player by calling {@link IGameInstance#onPlayerLeft(Player) onPlayerLeft(player)}. */
+  /** Remove a player by calling {@link IGameInstance#onPlayerLeft(Player, ScoreCause) onPlayerLeft}. */
   public void removePlayer(Player player, XStreamClient.DisconnectCause cause) {
     logger.info("Removing {} from {}", player, this);
     this.game.onPlayerLeft(player, cause == XStreamClient.DisconnectCause.DISCONNECTED ? ScoreCause.REGULAR : null);

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -8,8 +8,8 @@ import sc.api.plugins.exceptions.GameLogicException;
 import sc.api.plugins.exceptions.RescuableClientException;
 import sc.api.plugins.exceptions.TooManyPlayersException;
 import sc.api.plugins.host.IGameListener;
+import sc.framework.plugins.AbstractGame;
 import sc.framework.plugins.Player;
-import sc.framework.plugins.RoundBasedGameInstance;
 import sc.helpers.HelperMethods;
 import sc.helpers.XStreamKt;
 import sc.networking.InvalidScoreDefinitionException;
@@ -499,7 +499,7 @@ public class GameRoom implements IGameListener {
 
     logger.info("Toggling PAUSE from {} to {}.", isPauseRequested(), pause);
     this.pauseRequested = pause;
-    RoundBasedGameInstance<Player> pausableGame = (RoundBasedGameInstance<Player>) this.game;
+    AbstractGame<Player> pausableGame = (AbstractGame<Player>) this.game;
     // pause game after current turn has finished
     pausableGame.setPauseMode(pause);
 
@@ -529,7 +529,7 @@ public class GameRoom implements IGameListener {
     }
     if (isPauseRequested()) {
       logger.info("Stepping.");
-      ((RoundBasedGameInstance<Player>) this.game).afterPause();
+      ((AbstractGame<Player>) this.game).afterPause();
     } else {
       logger.warn("Can't step if the game is not paused.");
     }
@@ -562,7 +562,7 @@ public class GameRoom implements IGameListener {
 
   /**
    * Return whether or not the game is paused or will be paused in the next turn.
-   * Refer to {@link RoundBasedGameInstance#isPaused()} for the current value.
+   * Refer to {@link AbstractGame#isPaused()} for the current value.
    */
   public boolean isPauseRequested() {
     return this.pauseRequested;

--- a/server/test/sc/framework/GameTest.kt
+++ b/server/test/sc/framework/GameTest.kt
@@ -31,11 +31,8 @@ class GameTest: WordSpec({
             game.start()
             game.activePlayer shouldNotBe null
         }
-        "pause" {
-            game.setPauseMode(true)
-            game.isPaused shouldBe true
-        }
         "stay paused after move" {
+            game.isPaused = true
             game.onRoundBasedAction(game.activePlayer!!, TestMove(1))
             game.isPaused shouldBe true
         }

--- a/server/test/sc/framework/GameTest.kt
+++ b/server/test/sc/framework/GameTest.kt
@@ -31,9 +31,11 @@ class GameTest: WordSpec({
             game.start()
             game.activePlayer shouldNotBe null
         }
-        "only pause after receiving a move" {
+        "pause" {
             game.setPauseMode(true)
-            game.isPaused shouldBe false
+            game.isPaused shouldBe true
+        }
+        "stay paused after move" {
             game.onRoundBasedAction(game.activePlayer!!, TestMove(1))
             game.isPaused shouldBe true
         }

--- a/server/test/sc/server/network/RequestTest.kt
+++ b/server/test/sc/server/network/RequestTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import sc.framework.plugins.RoundBasedGameInstance
+import sc.framework.plugins.AbstractGame
 import sc.networking.clients.LobbyClient
 import sc.protocol.requests.*
 import sc.server.Configuration
@@ -363,8 +363,7 @@ class RequestTest: RealServerTest() {
         p1Listener.playerEventReceived = false
         p2Listener.playerEventReceived = false
         player1.send(PauseGameRequest(room.id, false))
-        TestHelper.waitUntilEqual(false, { (room.game as RoundBasedGameInstance<*>).isPaused }, 2000)
-        
+        TestHelper.waitUntilEqual(false, { (room.game as AbstractGame<*>).isPaused }, 2000)
         
         TestHelper.waitMillis(500)
         assertTrue(p2Listener.playerEventReceived)

--- a/server/test/sc/server/plugins/TestGame.kt
+++ b/server/test/sc/server/plugins/TestGame.kt
@@ -9,7 +9,6 @@ import sc.framework.plugins.RoundBasedGameInstance
 import sc.protocol.responses.ProtocolMessage
 import sc.server.helpers.TestTeam
 import sc.shared.*
-import java.util.*
 
 class TestGame : RoundBasedGameInstance<TestPlayer>(TestPlugin.TEST_PLUGIN_UUID) {
     private val state = TestGameState()
@@ -22,7 +21,7 @@ class TestGame : RoundBasedGameInstance<TestPlayer>(TestPlugin.TEST_PLUGIN_UUID)
     }
 
     override fun checkWinCondition(): WinCondition? {
-        return if (this.round > 1) {
+        return if (state.round > 1) {
             WinCondition(if (state.state % 2 == 0) TestTeam.RED else TestTeam.BLUE, TestWinReason.WIN)
         } else null
     }
@@ -60,8 +59,6 @@ class TestGame : RoundBasedGameInstance<TestPlayer>(TestPlugin.TEST_PLUGIN_UUID)
     override fun loadGameInfo(gameInfo: Any) {}
 
     override val winners: List<Player> = emptyList()
-
-    override val players: MutableList<TestPlayer> = ArrayList<TestPlayer>(super.players)
 
     /** Sends welcomeMessage to all listeners and notify player on new gameStates or MoveRequests  */
     override fun start() {

--- a/server/test/sc/server/plugins/TestGame.kt
+++ b/server/test/sc/server/plugins/TestGame.kt
@@ -3,14 +3,14 @@ package sc.server.plugins
 import org.slf4j.LoggerFactory
 import sc.api.plugins.IGameState
 import sc.api.plugins.exceptions.TooManyPlayersException
+import sc.framework.plugins.AbstractGame
 import sc.framework.plugins.ActionTimeout
 import sc.framework.plugins.Player
-import sc.framework.plugins.RoundBasedGameInstance
 import sc.protocol.responses.ProtocolMessage
 import sc.server.helpers.TestTeam
 import sc.shared.*
 
-class TestGame : RoundBasedGameInstance<TestPlayer>(TestPlugin.TEST_PLUGIN_UUID) {
+class TestGame : AbstractGame<TestPlayer>(TestPlugin.TEST_PLUGIN_UUID) {
     private val state = TestGameState()
     
     override fun onRoundBasedAction(fromPlayer: Player, data: ProtocolMessage) {


### PR DESCRIPTION
The original pausing behavior for the Game only considered it paused once there was no pending move anymore.
I didn't see the point in maintaining extra logic for that, so the pause state is now set directly.

Fixes #354