### PR TITLE
chore(gradle): remove custom startScripts task

### DIFF
--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -126,12 +126,12 @@ tasks {
             val server =
                 ProcessBuilder(
                     "java",
-                    "-Dlogback.configurationFile=${project("server").projectDir.resolve("configuration/logback-trace.xml")}",
-                    "-jar", project("server").tasks.jar.get().archiveFile.get().asFile.absolutePath
+                    "-Dlogback.configurationFile=${project(":server").projectDir.resolve("configuration/logback-trace.xml")}",
+                    "-jar", (project(":server").getTasksByName("jar", false).single() as Jar).archiveFile.get().asFile.absolutePath
                 )
                     .redirectOutput(testLogDir.resolve("server.log"))
                     .redirectError(testLogDir.resolve("server-err.log"))
-                    .directory(project("server").buildDir.resolve("runnable"))
+                    .directory(project(":server").buildDir.resolve("runnable"))
                     .start()
             Thread.sleep(400)
             val startClient: (Int) -> Process = {

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -1,14 +1,12 @@
 import org.gradle.kotlin.dsl.support.unzipTo
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import sc.gradle.ScriptsTask
 import java.util.concurrent.atomic.AtomicBoolean
 
 plugins {
     maven
     kotlin("jvm") version "1.4.20"
     id("org.jetbrains.dokka") version "0.10.1"
-    id("scripts-task")
     
     id("com.github.ben-manes.versions") version "0.36.0"
     id("se.patrikerdes.use-latest-versions") version "0.2.15"
@@ -198,11 +196,12 @@ tasks {
             unzipTo(unzipped, deployDir.resolve("software-challenge-server.zip"))
     
             println("Testing TestClient...")
+            val command = mutableListOf("java").apply {
+                addAll((project(":test-client").getTasksByName("createStartScripts", false).single() as CreateStartScripts).defaultJvmOpts!!)
+                addAll(arrayOf("--start-server", "--tests", testClientGames.toString(), "--port", "13055"))
+            }
             val testClient =
-                    ProcessBuilder(
-                            (project(":test-client").getTasksByName("createStartScripts", false).single() as ScriptsTask).content.split(' ') +
-                            arrayOf("--start-server", "--tests", testClientGames.toString(), "--port", "13055")
-                    )
+                    ProcessBuilder(command)
                             .redirectOutput(testLogDir.resolve("test-client.log"))
                             .redirectError(testLogDir.resolve("test-client-err.log"))
                             .directory(unzipped)

--- a/helpers/test-client/build.gradle.kts
+++ b/helpers/test-client/build.gradle.kts
@@ -28,12 +28,13 @@ tasks {
     jar {
         dependsOn(createStartScripts)
         doFirst {
-            val libs = arrayListOf("plugins/${project.property("game")}.jar", "software-challenge-server.jar", "server.jar")
-            libs.addAll(configurations.default.get().map  { "lib/" + it.name })
-            manifest.attributes["Class-Path"] = libs.joinToString(" ")
+            manifest.attributes["Class-Path"] =
+                configurations.default.get().map { "lib/" + it.name }
+                        .plus("server.jar")
+                        .joinToString(" ")
             copy {
                 from("src/logback-tests.xml")
-                into("build/libs")
+                into(destinationDirectory)
             }
         }
     }

--- a/helpers/test-client/build.gradle.kts
+++ b/helpers/test-client/build.gradle.kts
@@ -19,10 +19,10 @@ dependencies {
 }
 
 tasks {
-    val createStartScripts by creating(ScriptsTask::class) {
-        destinationDir = file("build/libs")
-        fileName = "start-tests"
-        content = "java -Dfile.encoding=UTF-8 -Dlogback.configurationFile=logback-tests.xml -jar test-client.jar"
+    val createStartScripts by creating(CreateStartScripts::class) {
+        outputDir = jar.get().destinationDirectory.asFile.get()
+        applicationName = "start-tests"
+        defaultJvmOpts = listOf("-Dfile.encoding=UTF-8", "-Dlogback.configurationFile=logback-tests.xml")
     }
 
     jar {

--- a/helpers/test-client/build.gradle.kts
+++ b/helpers/test-client/build.gradle.kts
@@ -10,7 +10,7 @@ sourceSets.main {
 }
 
 application {
-    mainClassName = "sc.TestClient"
+    mainClass.set("sc.TestClient")
 }
 
 dependencies {

--- a/helpers/test-client/build.gradle.kts
+++ b/helpers/test-client/build.gradle.kts
@@ -14,7 +14,7 @@ application {
 }
 
 dependencies {
-    implementation(project(":plugin"))
+    // TODO this dependency is only for accessing the Configuration, remove it
     implementation(project(":server"))
 }
 

--- a/helpers/test-client/build.gradle.kts
+++ b/helpers/test-client/build.gradle.kts
@@ -28,14 +28,14 @@ tasks {
     jar {
         dependsOn(createStartScripts)
         doFirst {
+            val libs = arrayListOf("plugins/${project.property("game")}.jar", "software-challenge-server.jar", "server.jar")
+            libs.addAll(configurations.default.get().map  { "lib/" + it.name })
+            manifest.attributes["Class-Path"] = libs.joinToString(" ")
             copy {
                 from("src/logback-tests.xml")
                 into("build/libs")
             }
         }
-        val libs = arrayListOf("plugins/${project.property("game")}.jar", "software-challenge-server.jar", "server.jar")
-        libs.addAll(configurations.default.get().map  { "lib/" + it.name })
-        manifest.attributes["Class-Path"] = libs.joinToString(" ")
     }
 
     run.configure {

--- a/helpers/test-client/src/sc/TestClient.java
+++ b/helpers/test-client/src/sc/TestClient.java
@@ -9,7 +9,6 @@ import sc.framework.plugins.Player;
 import sc.networking.INetworkInterface;
 import sc.networking.TcpNetwork;
 import sc.networking.clients.XStreamClient;
-import sc.plugin2021.util.Constants;
 import sc.protocol.requests.*;
 import sc.protocol.responses.*;
 import sc.server.Configuration;
@@ -263,7 +262,8 @@ public class TestClient extends XStreamClient {
                 logger.error("{} crashed, look into {}", player.name, logDir);
                 exit(2);
               }
-            if (slept > Constants.GAME_TIMEOUT) {
+            // TODO move timeout to GamePlugin and obtain it
+            if (slept > 200.000) {
               logger.error("The game seems to hang, exiting!");
               exit(2);
             }
@@ -363,7 +363,8 @@ public class TestClient extends XStreamClient {
     players:
     for (int i = 0; i < 2; i++) {
       double binominalCD = 0.0;
-      for (int k = 0; k <= players[i].score.getScoreValues().get(0).getValue().intValue() / Constants.WIN_SCORE; k++) {
+      // TODO use global WIN_SCORE constant instead of hardcoding 2
+      for (int k = 0; k <= players[i].score.getScoreValues().get(0).getValue().intValue() / 2; k++) {
         binominalCD += binominalPD.applyAsDouble(k);
         if (binominalCD > significance)
           continue players;

--- a/player/build.gradle.kts
+++ b/player/build.gradle.kts
@@ -50,7 +50,7 @@ tasks {
             from("src")
             into("src")
         }, copySpec {
-            from(configurations.default, arrayOf("sdk", "plugin").map { project(":$it").tasks.getByName("sourcesJar").outputs.files })
+            from(configurations.default, arrayOf("sdk", "plugin").map { project(":$it").getTasksByName("sourcesJar", false).single().outputs.files })
             into("lib")
         })
         if(!project.hasProperty("nodoc")) {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -50,14 +50,14 @@ tasks {
     
     val deploy by creating(Zip::class) {
         group = "distribution"
-        dependsOn(project(":test-client").tasks.jar, ":player:shadowJar", makeRunnable)
+        dependsOn(":test-client:jar", ":player:shadowJar", makeRunnable)
         destinationDirectory.set(deployDir)
         archiveBaseName.set("software-challenge-server")
         from(runnableDir)
-        if(project.property("enableTestClient") as Boolean)
-            from(project(":test-client").buildDir.resolve("libs"))
         doFirst {
-            from(project(":player").tasks["shadowJar"].outputs)
+            if(project.property("enableTestClient") as Boolean)
+                from((project(":test-client").getTasksByName("jar", false).single() as Jar).destinationDirectory)
+            from(project(":player").getTasksByName("shadowJar", false).single().outputs)
             exec {
                 commandLine("git", "rev-parse", "HEAD")
                 standardOutput = runnableDir.resolve("version").outputStream()

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -4,15 +4,15 @@ plugins {
     application
 }
 
+application {
+    mainClass.set("sc.server.Application")
+    applicationDefaultJvmArgs = listOf("-Dfile.encoding=UTF-8",
+            "-XX:+PrintGC", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-Xloggc:gc.log")
+}
+
 sourceSets {
     main.get().java.srcDir("src")
     test.get().java.srcDir("test")
-}
-
-application {
-    mainClassName = "sc.server.Application"
-    applicationDefaultJvmArgs = listOf("-Dfile.encoding=UTF-8",
-            "-XX:+PrintGC", "-XX:+PrintGCDetails", "-XX:+PrintGCDateStamps", "-Xloggc:gc.log")
 }
 
 dependencies {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,7 +1,7 @@
-import sc.gradle.ScriptsTask
-
 plugins {
     application
+    // TODO https://github.com/CAU-Kiel-Tech-Inf/backend/issues/265
+    distribution
 }
 
 application {
@@ -27,10 +27,10 @@ val deployDir: File by project
 tasks {
     val runnableDir = buildDir.resolve("runnable")
     
-    val createStartScripts by creating(ScriptsTask::class) {
-        destinationDir = runnableDir
-        fileName = "start"
-        content = "java -Dfile.encoding=UTF-8 -Dlogback.configurationFile=logback.xml -jar server.jar"
+    startScripts {
+        outputDir = runnableDir
+        applicationName = "start-server"
+        defaultJvmOpts = listOf("-Dfile.encoding=UTF-8", "-Dlogback.configurationFile=logback.xml")
     }
     
     val copyConfig by creating(Copy::class) {
@@ -43,7 +43,7 @@ tasks {
     
     val makeRunnable by creating(Copy::class) {
         group = "distribution"
-        dependsOn(jar, copyConfig, createStartScripts)
+        dependsOn(jar, copyConfig, startScripts)
         from(configurations.default)
         into(runnableDir.resolve("lib"))
     }
@@ -91,9 +91,10 @@ tasks {
     }
     
     jar {
-        destinationDirectory.set(runnableDir)
+        destinationDirectory.set(runnableDir.resolve("lib"))
         doFirst {
-            manifest.attributes["Class-Path"] = configurations.default.get().joinToString(" ") { "lib/" + it.name }
+            manifest.attributes["Class-Path"] =
+                    configurations.default.get().joinToString(" ") { "lib/" + it.name }
         }
     }
     

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -16,7 +16,7 @@ application {
 }
 
 dependencies {
-    implementation(project(":sdk"))
+    api(project(":sdk"))
     runtimeOnly(project(":plugin"))
     
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine") // legacy java tests


### PR DESCRIPTION
Current issues:
- the start-script hardcodes classpath to lib:
  https://github.com/gradle/gradle/issues/7033
- script assumes it is in a bin directory, but I want it in root ("pwd -P")

https://docs.gradle.org/current/dsl/org.gradle.jvm.application.tasks.CreateStartScripts.html

May fix #265