### PR TITLE
docs(changelog): keep a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
+
+## [Unreleased]
+
+## [21.4.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.4.0)
+- Adjust Gamestate XML (#374)
+
+## [21.3.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.3.0) - 2021-01-29
+### Fixed
+- Send final Gamestate to listeners when a game ends (#364)
+- Remove extra field from Move/Piece XML (23589a153)
+- Player dependency declarations (#373)
+  
+## Added
+- Implement cloning for GameState & Board (#356)
+- Add README for player (#373)
+- Create CONTRIBUTING & GUIDELINES (#360)
+- Modularize XStream initialization using ServiceLoader (#352)
+  
+## Changed
+- Improve logback config (#371)
+- Improve gradle configuration & TestClient build (#368)
+- TestClient: Make it work (#372) & load current Game id from classpath (#367)
+
+## [21.2.1](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.1) - 2020-12-18
+- improve internal build logic (#343)
+- feat(plugin): improve & translate toString messages
+- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions (#321)
+
+## [21.2.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.0) - 2020-12-14
+- converted lots of classes to Kotlin
+- internal Protocol updates & game flow adjustments
+- updated many tests
+
+## 21 - Game Blokus
+
+## 20 - Game Hive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 ## [Unreleased]
 
 ## [21.4.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.4.0)
+### Changed
 - Adjust Gamestate XML ([#374](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/374))
 
 ## [21.3.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.3.0) - 2021-01-29
@@ -13,21 +14,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 - Remove extra field from Move/Piece XML ([23589a153](https://github.com/CAU-Kiel-Tech-Inf/backend/commit/23589a153e8cd3c5b1b3257ff35f66ebbb8d3012))
 - Player dependency declarations ([#373](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373))
   
-## Added
+### Added
 - Implement cloning for GameState & Board ([#356](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/356))
 - Add README for player ([#373](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373))
 - Create CONTRIBUTING & GUIDELINES ([#360](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/360))
 - Modularize XStream initialization using ServiceLoader ([#352](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/352))
   
-## Changed
+### Changed
 - Improve logback config ([#371](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/371))
 - Improve gradle configuration & TestClient build ([#368](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368))
 - TestClient: Make it work ([#372](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/372)) & load current Game id from classpath ([#367](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/367))
 
 ## [21.2.1](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.1) - 2020-12-18
-- improve internal build logic ([#343](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/343))
-- feat(plugin): improve & translate toString messages
-- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions ([#321](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/321))
+- Improve internal build logic ([#343](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/343))
+- Improve & translate toString messages
+- Use MoveMistakes to construct InvalidMoveExceptions ([#321](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/321))
 
 ## [21.2.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.0) - 2020-12-14
 - converted lots of classes to Kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 ## [Unreleased]
 
 ## [21.4.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.4.0)
-- Adjust Gamestate XML (#374)
+- Adjust Gamestate XML (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/374)
 
 ## [21.3.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.3.0) - 2021-01-29
 ### Fixed
-- Send final Gamestate to listeners when a game ends (#364)
-- Remove extra field from Move/Piece XML (23589a153)
-- Player dependency declarations (#373)
+- Send final Gamestate to listeners when a game ends (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/364)
+- Remove extra field from Move/Piece XML (23589a153e8cd3c5b1b3257ff35f66ebbb8d3012)
+- Player dependency declarations (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373)
   
 ## Added
-- Implement cloning for GameState & Board (#356)
-- Add README for player (#373)
-- Create CONTRIBUTING & GUIDELINES (#360)
-- Modularize XStream initialization using ServiceLoader (#352)
+- Implement cloning for GameState & Board (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/356)
+- Add README for player (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373)
+- Create CONTRIBUTING & GUIDELINES (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/360)
+- Modularize XStream initialization using ServiceLoader (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/352)
   
 ## Changed
-- Improve logback config (#371)
-- Improve gradle configuration & TestClient build (#368)
-- TestClient: Make it work (#372) & load current Game id from classpath (#367)
+- Improve logback config (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/371)
+- Improve gradle configuration & TestClient build (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368)
+- TestClient: Make it work (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/372) & load current Game id from classpath (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/367)
 
 ## [21.2.1](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.1) - 2020-12-18
-- improve internal build logic (#343)
+- improve internal build logic (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/343)
 - feat(plugin): improve & translate toString messages
-- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions (#321)
+- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/321)
 
 ## [21.2.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.0) - 2020-12-14
 - converted lots of classes to Kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 ## [Unreleased]
 
 ## [21.4.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.4.0)
-- Adjust Gamestate XML (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/374)
+- Adjust Gamestate XML ([#374](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/374))
 
 ## [21.3.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.3.0) - 2021-01-29
 ### Fixed
-- Send final Gamestate to listeners when a game ends (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/364)
-- Remove extra field from Move/Piece XML (23589a153e8cd3c5b1b3257ff35f66ebbb8d3012)
-- Player dependency declarations (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373)
+- Send final Gamestate to listeners when a game ends ([#364](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/364))
+- Remove extra field from Move/Piece XML ([23589a153](https://github.com/CAU-Kiel-Tech-Inf/backend/commit/23589a153e8cd3c5b1b3257ff35f66ebbb8d3012))
+- Player dependency declarations ([#373](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373))
   
 ## Added
-- Implement cloning for GameState & Board (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/356)
-- Add README for player (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373)
-- Create CONTRIBUTING & GUIDELINES (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/360)
-- Modularize XStream initialization using ServiceLoader (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/352)
+- Implement cloning for GameState & Board ([#356](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/356))
+- Add README for player ([#373](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/373))
+- Create CONTRIBUTING & GUIDELINES ([#360](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/360))
+- Modularize XStream initialization using ServiceLoader ([#352](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/352))
   
 ## Changed
-- Improve logback config (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/371)
-- Improve gradle configuration & TestClient build (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368)
-- TestClient: Make it work (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/372) & load current Game id from classpath (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/367)
+- Improve logback config ([#371](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/371))
+- Improve gradle configuration & TestClient build ([#368](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368))
+- TestClient: Make it work ([#372](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/372)) & load current Game id from classpath ([#367](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/367))
 
 ## [21.2.1](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.1) - 2020-12-18
-- improve internal build logic (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/343)
+- improve internal build logic ([#343](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/343))
 - feat(plugin): improve & translate toString messages
-- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions (https://github.com/CAU-Kiel-Tech-Inf/backend/pull/321)
+- feat(plugin): use MoveMistakes to construct InvalidMoveExceptions ([#321](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/321))
 
 ## [21.2.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.0) - 2020-12-14
 - converted lots of classes to Kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 
+The `x.y.z` version is tracked in [gradle.properties](./gradle.properties) to enable programmatic updating via the Gradle release task.
+The version should always be in sync with the [GUI](https://github.com/CAU-Kiel-Tech-Inf/gui) and have a tag in both repositories.
+
+- The major version `x` corresponds to the year of the contest and thus only changes once a year
+- `y` and `z` should follow the [semantic versioning guidelines](https://semver.org) for MAJOR and PATCH respectively
+
 ## [Unreleased]
 
 ## [21.4.0](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.4.0)
@@ -22,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
   
 ### Changed
 - Improve logback config ([#371](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/371))
-- Improve gradle configuration & TestClient build ([#368](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368))
+- Improve Gradle configuration & TestClient build ([#368](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/368))
 - TestClient: Make it work ([#372](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/372)) & load current Game id from classpath ([#367](https://github.com/CAU-Kiel-Tech-Inf/backend/pull/367))
 
 ## [21.2.1](https://github.com/CAU-Kiel-Tech-Inf/backend/commits/21.2.1) - 2020-12-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The `x.y.z` version is tracked in [gradle.properties](./gradle.properties) to en
 The version should always be in sync with the [GUI](https://github.com/CAU-Kiel-Tech-Inf/gui) and have a tag in both repositories.
 
 - The major version `x` corresponds to the year of the contest and thus only changes once a year
-- `y` and `z` should follow the [semantic versioning guidelines](https://semver.org) for MAJOR and PATCH respectively
+- `y` is bumped for any major updates or backwards-incompatible changes
 
 ## [Unreleased]
 

--- a/player/configuration/README.md
+++ b/player/configuration/README.md
@@ -1,6 +1,6 @@
 # Dein Software-Challenge Spieler
 
-In diesem Packet ist alles dabei, was du brauchst, um einen Spieler für die
+In diesem Paket ist alles dabei, was du brauchst, um einen Spieler für die
 [Software-Challenge YEAR](https://software-challenge.de) zu entwickeln!
 
 In der [Dokumentation](https://cau-kiel-tech-inf.github.io/socha-enduser-docs)
@@ -8,7 +8,7 @@ findest du eine Anleitung, wie du eine [eigene Strategie umsetzen kannst](https:
 
 ## Den Spieler einsetzen
 
-Dieses Projekt ist mit [Gradle](https://gradle.org/) vorkonfiguriert, wodurch
+Dieses Projekt ist mit [Gradle](https://gradle.org) vorkonfiguriert, wodurch
 alle Abhängigkeiten automatisch sichergestellt werden und du dich voll und ganz
 auf das konzentrieren kannst, was zählt – deine Strategie umzusetzen :)
 


### PR DESCRIPTION
Finally got around to creating it - then we can simply copy the current section for a Release. Added some history, but not too much

Also, I've added links to view the commit history for each release, which can be quite handy.

Squash merge

- [ ] TODO for later: Automatically generate release description from changelog in gradle release task :D