### PR TITLE
fix(plugin): clone GameState fully

### DIFF
--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -31,17 +31,18 @@ class GameState @JvmOverloads constructor(
         /** Speichert für jede Farbe, die alle Steine gelegt hat, ob das Monomino zuletzt gelegt wurde. */
         @XStreamAsAttribute
         val lastMoveMono: HashMap<Color, Boolean> = HashMap(),
-        blueShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
-        yellowShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
-        redShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
-        greenShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
+        blueShapes: LinkedHashSet<PieceShape> = PieceShape.values().toLinkedHashSet(),
+        yellowShapes: LinkedHashSet<PieceShape> = PieceShape.values().toLinkedHashSet(),
+        redShapes: LinkedHashSet<PieceShape> = PieceShape.values().toLinkedHashSet(),
+        greenShapes: LinkedHashSet<PieceShape> = PieceShape.values().toLinkedHashSet(),
+        validColors: LinkedHashSet<Color> = Color.values().toLinkedHashSet()
 ): TwoPlayerGameState<Player>(Team.ONE) {
     
     companion object {
         val logger = LoggerFactory.getLogger(GameState::class.java)
     }
     
-    constructor(other: GameState): this(other.first, other.second, other.startPiece, other.board.clone(), other.turn, other.lastMove, HashMap(other.lastMoveMono), LinkedHashSet(other.blueShapes), LinkedHashSet(other.yellowShapes), LinkedHashSet(other.redShapes), LinkedHashSet(other.greenShapes))
+    constructor(other: GameState): this(other.first, other.second, other.startPiece, other.board.clone(), other.turn, other.lastMove, HashMap(other.lastMoveMono), LinkedHashSet(other.blueShapes), LinkedHashSet(other.yellowShapes), LinkedHashSet(other.redShapes), LinkedHashSet(other.greenShapes), LinkedHashSet(other.validColors))
     
     private val blueShapes = blueShapes
     private val yellowShapes = yellowShapes
@@ -90,7 +91,7 @@ class GameState @JvmOverloads constructor(
         get() = orderedColors[turn % Constants.COLORS]
     
     /** Liste der Farben, die noch im Spiel sind. */
-    private val validColors = Color.values().toCollection(LinkedHashSet(Color.values().size))
+    private val validColors = validColors
     
     /** Beendet das Spiel, indem alle Farben entfernt werden. */
     internal fun clearValidColors() = validColors.clear()
@@ -162,6 +163,7 @@ class GameState @JvmOverloads constructor(
                 && yellowShapes == other.yellowShapes
                 && redShapes == other.redShapes
                 && greenShapes == other.greenShapes
+                && validColors == other.validColors
                )
     }
     
@@ -177,7 +179,10 @@ class GameState @JvmOverloads constructor(
         result = 31 * result + yellowShapes.hashCode()
         result = 31 * result + redShapes.hashCode()
         result = 31 * result + greenShapes.hashCode()
+        result = 31 * result + validColors.hashCode()
         return result
     }
     
 }
+
+fun <T> Array<T>.toLinkedHashSet() = toCollection(LinkedHashSet(size))

--- a/plugin/src/shared/sc/plugin2021/GameState.kt
+++ b/plugin/src/shared/sc/plugin2021/GameState.kt
@@ -30,19 +30,23 @@ class GameState @JvmOverloads constructor(
         override var lastMove: Move? = null,
         /** Speichert für jede Farbe, die alle Steine gelegt hat, ob das Monomino zuletzt gelegt wurde. */
         @XStreamAsAttribute
-        val lastMoveMono: MutableMap<Color, Boolean> = mutableMapOf()
+        val lastMoveMono: HashMap<Color, Boolean> = HashMap(),
+        blueShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
+        yellowShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
+        redShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
+        greenShapes: LinkedHashSet<PieceShape> = PieceShape.values().toCollection(LinkedHashSet(PieceShape.values().size)),
 ): TwoPlayerGameState<Player>(Team.ONE) {
     
     companion object {
         val logger = LoggerFactory.getLogger(GameState::class.java)
     }
     
-    constructor(other: GameState): this(other.first, other.second, other.startPiece, other.board.clone(), other.turn, other.lastMove, HashMap(other.lastMoveMono))
+    constructor(other: GameState): this(other.first, other.second, other.startPiece, other.board.clone(), other.turn, other.lastMove, HashMap(other.lastMoveMono), LinkedHashSet(other.blueShapes), LinkedHashSet(other.yellowShapes), LinkedHashSet(other.redShapes), LinkedHashSet(other.greenShapes))
     
-    private val blueShapes: MutableSet<PieceShape> = PieceShape.values().toMutableSet()
-    private val yellowShapes: MutableSet<PieceShape> = PieceShape.values().toMutableSet()
-    private val redShapes: MutableSet<PieceShape> = PieceShape.values().toMutableSet()
-    private val greenShapes: MutableSet<PieceShape> = PieceShape.values().toMutableSet()
+    private val blueShapes = blueShapes
+    private val yellowShapes = yellowShapes
+    private val redShapes = redShapes
+    private val greenShapes = greenShapes
     
     /** Gib eine Liste aller nicht gesetzter Steine der [Color] zurück. */
     fun undeployedPieceShapes(color: Color = currentColor): MutableSet<PieceShape> = when (color) {
@@ -86,7 +90,7 @@ class GameState @JvmOverloads constructor(
         get() = orderedColors[turn % Constants.COLORS]
     
     /** Liste der Farben, die noch im Spiel sind. */
-    private val validColors: MutableSet<Color> = Color.values().toMutableSet()
+    private val validColors = Color.values().toCollection(LinkedHashSet(Color.values().size))
     
     /** Beendet das Spiel, indem alle Farben entfernt werden. */
     internal fun clearValidColors() = validColors.clear()
@@ -153,7 +157,12 @@ class GameState @JvmOverloads constructor(
                 && board == other.board
                 && lastMove == other.lastMove
                 && lastMoveMono == other.lastMoveMono
-                && turn == other.turn)
+                && turn == other.turn
+                && blueShapes == other.blueShapes
+                && yellowShapes == other.yellowShapes
+                && redShapes == other.redShapes
+                && greenShapes == other.greenShapes
+               )
     }
     
     override fun hashCode(): Int {
@@ -164,6 +173,10 @@ class GameState @JvmOverloads constructor(
         result = 31 * result + (lastMove?.hashCode() ?: 0)
         result = 31 * result + lastMoveMono.hashCode()
         result = 31 * result + turn
+        result = 31 * result + blueShapes.hashCode()
+        result = 31 * result + yellowShapes.hashCode()
+        result = 31 * result + redShapes.hashCode()
+        result = 31 * result + greenShapes.hashCode()
         return result
     }
     

--- a/plugin/src/test/sc/plugin2021/GameStateTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameStateTest.kt
@@ -70,8 +70,21 @@ class GameStateTest: WordSpec({
             }
         }
         "cloned" should {
+            val cloned = state.clone()
             "preserve equality" {
-                state.clone() shouldBe state
+                 cloned shouldBe state
+            }
+            "not be equal when lastMoveMono changes" {
+                cloned shouldBe state
+                cloned.lastMoveMono[Color.RED] = true
+                cloned shouldNotBe state
+            }
+            "not be equal when undeployedPieces changes" {
+                cloned shouldBe state
+                GameRuleLogic.isFirstMove(cloned) shouldBe true
+                cloned.undeployedPieceShapes().remove(cloned.undeployedPieceShapes().first())
+                GameRuleLogic.isFirstMove(cloned) shouldBe false
+                cloned shouldNotBe state
             }
             val otherState = GameState(lastMove = SetMove(Piece(Color.GREEN, 0)))
             "preserve inequality" {

--- a/plugin/src/test/sc/plugin2021/GameStateTest.kt
+++ b/plugin/src/test/sc/plugin2021/GameStateTest.kt
@@ -74,17 +74,27 @@ class GameStateTest: WordSpec({
             "preserve equality" {
                  cloned shouldBe state
             }
-            "not be equal when lastMoveMono changes" {
+            "not equal original when lastMoveMono changed" {
                 cloned shouldBe state
                 cloned.lastMoveMono[Color.RED] = true
                 cloned shouldNotBe state
             }
-            "not be equal when undeployedPieces changes" {
+            "not equal original when undeployedPieces changed" {
                 cloned shouldBe state
                 GameRuleLogic.isFirstMove(cloned) shouldBe true
                 cloned.undeployedPieceShapes().remove(cloned.undeployedPieceShapes().first())
                 GameRuleLogic.isFirstMove(cloned) shouldBe false
                 cloned shouldNotBe state
+            }
+            "respect validColors" {
+                state.removeColor(Color.BLUE)
+                val newClone = state.clone()
+                newClone shouldBe state
+                cloned shouldNotBe state
+                newClone.removeColor(Color.BLUE)
+                newClone shouldBe state
+                newClone.removeColor(Color.RED)
+                newClone shouldNotBe state
             }
             val otherState = GameState(lastMove = SetMove(Piece(Color.GREEN, 0)))
             "preserve inequality" {

--- a/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
+++ b/plugin/src/test/sc/plugin2021/xstream/ConverterTest.kt
@@ -44,7 +44,7 @@ class ConverterTest: WordSpec({
                 state shouldSerializeTo """
                     <state turn="0" round="1" startPiece="PENTO_L">
                       <startTeam class="team">ONE</startTeam>
-                      <blueShapes class="linked-hash-set">
+                      <blueShapes>
                         <shape>MONO</shape>
                         <shape>DOMINO</shape>
                         <shape>TRIO_L</shape>
@@ -67,7 +67,7 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_X</shape>
                         <shape>PENTO_Y</shape>
                       </blueShapes>
-                      <yellowShapes class="linked-hash-set">
+                      <yellowShapes>
                         <shape>MONO</shape>
                         <shape>DOMINO</shape>
                         <shape>TRIO_L</shape>
@@ -90,7 +90,7 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_X</shape>
                         <shape>PENTO_Y</shape>
                       </yellowShapes>
-                      <redShapes class="linked-hash-set">
+                      <redShapes>
                         <shape>MONO</shape>
                         <shape>DOMINO</shape>
                         <shape>TRIO_L</shape>
@@ -113,7 +113,7 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_X</shape>
                         <shape>PENTO_Y</shape>
                       </redShapes>
-                      <greenShapes class="linked-hash-set">
+                      <greenShapes>
                         <shape>MONO</shape>
                         <shape>DOMINO</shape>
                         <shape>TRIO_L</shape>
@@ -136,7 +136,7 @@ class ConverterTest: WordSpec({
                         <shape>PENTO_X</shape>
                         <shape>PENTO_Y</shape>
                       </greenShapes>
-                      <validColors class="linked-hash-set">
+                      <validColors>
                         <color>BLUE</color>
                         <color>YELLOW</color>
                         <color>RED</color>
@@ -154,7 +154,7 @@ class ConverterTest: WordSpec({
                         <field x="8" y="6" content="YELLOW"/>
                         <field x="5" y="9" content="BLUE"/>
                       </board>
-                      <lastMoveMono class="linked-hash-map"/>
+                      <lastMoveMono/>
                     </state>""".trimIndent()
             }
         }


### PR DESCRIPTION
GameState cloning (and hashcode) previously did not include the undeployedPieces, leading to an obviously wrong result.

The little XML change only removes superfluous java-specific attributes that aren't even useful to anything but XStream.