### PR TITLE
Split up the responsibilities of the LobbyClient

### DIFF
--- a/plugin/src/client/sc/plugin2021/AbstractClient.kt
+++ b/plugin/src/client/sc/plugin2021/AbstractClient.kt
@@ -51,10 +51,6 @@ abstract class AbstractClient(
     var team: Team? = null
         private set
     
-    /** Tell this client to observe the game given by the preparation handler. */
-    fun observeGame(handle: GamePreparedResponse): IControllableGame =
-            client.observe(handle.roomId)
-    
     /** Called for any new message sent to the game room, e.g., move requests. */
     override fun onRoomMessage(roomId: String, data: RoomMessage) {
         when(data) {

--- a/sdk/src/server-api/sc/networking/clients/AdminClient.kt
+++ b/sdk/src/server-api/sc/networking/clients/AdminClient.kt
@@ -12,29 +12,26 @@ class AdminClient(private val client: LobbyClient) {
         client.send(PrepareGameRequest(gameType))
     }
     
-    fun prepareGame(gameType: String, startPaused: Boolean) {
+    fun prepareGame(gameType: String, pause: Boolean) {
         client.send(PrepareGameRequest(
                 gameType,
                 SlotDescriptor("player1", false),
                 SlotDescriptor("player2", false),
-                startPaused)
+                pause)
         )
     }
     
-    /** Takes control of the game in the given room.
-     * @param isPaused whether the game to observe is already paused.
-     */
-    fun observeAndControl(roomId: String, isPaused: Boolean): IControllableGame {
-        val controller = ControllingClient(client, roomId, isPaused)
-        observe(roomId) {}
-        return controller
-    }
+    /** Returns an [IGameController] to control the given room. */
+    fun control(roomId: String): IGameController =
+            GameController(roomId, client)
     
+    /** Registers [listener] onto the given room. */
     fun observe(roomId: String, listener: (RoomMessage) -> Unit) {
         client.observeRoom(roomId, listener)
         client.send(ObservationRequest(roomId))
     }
     
+    /** Opens up a previously reserved slot. */
     fun freeReservation(reservation: String) {
         client.send(FreeReservationRequest(reservation))
     }

--- a/sdk/src/server-api/sc/networking/clients/AdminClient.kt
+++ b/sdk/src/server-api/sc/networking/clients/AdminClient.kt
@@ -4,21 +4,11 @@ import sc.protocol.requests.FreeReservationRequest
 import sc.protocol.requests.ObservationRequest
 import sc.protocol.requests.PrepareGameRequest
 import sc.protocol.room.RoomMessage
-import sc.shared.SlotDescriptor
 
 class AdminClient(private val client: LobbyClient) {
     
-    fun prepareGame(gameType: String) {
-        client.send(PrepareGameRequest(gameType))
-    }
-    
-    fun prepareGame(gameType: String, pause: Boolean) {
-        client.send(PrepareGameRequest(
-                gameType,
-                SlotDescriptor("player1", false),
-                SlotDescriptor("player2", false),
-                pause)
-        )
+    fun prepareGame(request: PrepareGameRequest) {
+        client.send(request)
     }
     
     /** Returns an [IGameController] to control the given room. */

--- a/sdk/src/server-api/sc/networking/clients/AdminClient.kt
+++ b/sdk/src/server-api/sc/networking/clients/AdminClient.kt
@@ -1,0 +1,69 @@
+package sc.networking.clients
+
+import sc.protocol.ProtocolPacket
+import sc.protocol.requests.AuthenticateRequest
+import sc.protocol.requests.FreeReservationRequest
+import sc.protocol.requests.ObservationRequest
+import sc.protocol.requests.PrepareGameRequest
+import sc.shared.SlotDescriptor
+
+class AdminClient(host: String, port: Int, password: String, private val messageHandler: (ProtocolPacket) -> Unit): XStreamClient(createTcpNetwork(host, port)) {
+    
+    init {
+        start()
+        send(AuthenticateRequest(password))
+    }
+    
+    override fun onObject(packet: ProtocolPacket) {
+        messageHandler(packet)
+    }
+    
+    fun prepareGame(gameType: String) {
+        send(PrepareGameRequest(gameType))
+    }
+    
+    fun prepareGame(gameType: String, startPaused: Boolean) {
+        send(PrepareGameRequest(
+                gameType,
+                SlotDescriptor("player1", false),
+                SlotDescriptor("player2", false),
+                startPaused)
+        )
+    }
+    
+    /** Takes control of the game in the given room and pauses it.  */
+    fun observeAndControl(roomId: String): IControllableGame {
+        val controller = observeAndControl(roomId, true)
+        controller.pause()
+        return controller
+    }
+    
+    /** Takes control of the game in the given room.
+     * @param isPaused whether the game to observe is already paused.
+     */
+    fun observeAndControl(roomId: String, isPaused: Boolean): IControllableGame {
+        val controller = ControllingClient(this, roomId, isPaused)
+        requestObservation(roomId)
+        return controller
+    }
+    
+    fun observe(roomId: String): ObservingClient {
+        return observe(roomId, false)
+    }
+    
+    fun observe(roomId: String, isPaused: Boolean): ObservingClient {
+        val observer = ObservingClient(roomId, isPaused)
+        requestObservation(roomId)
+        return observer
+    }
+    
+    private fun requestObservation(roomId: String) {
+        start()
+        send(ObservationRequest(roomId))
+    }
+    
+    fun freeReservation(reservation: String) {
+        send(FreeReservationRequest(reservation))
+    }
+    
+}

--- a/sdk/src/server-api/sc/networking/clients/AdminClient.kt
+++ b/sdk/src/server-api/sc/networking/clients/AdminClient.kt
@@ -1,29 +1,18 @@
 package sc.networking.clients
 
-import sc.protocol.ProtocolPacket
-import sc.protocol.requests.AuthenticateRequest
 import sc.protocol.requests.FreeReservationRequest
 import sc.protocol.requests.ObservationRequest
 import sc.protocol.requests.PrepareGameRequest
 import sc.shared.SlotDescriptor
 
-class AdminClient(host: String, port: Int, password: String, private val messageHandler: (ProtocolPacket) -> Unit): XStreamClient(createTcpNetwork(host, port)) {
-    
-    init {
-        start()
-        send(AuthenticateRequest(password))
-    }
-    
-    override fun onObject(packet: ProtocolPacket) {
-        messageHandler(packet)
-    }
+class AdminClient(private val client: XStreamClient) {
     
     fun prepareGame(gameType: String) {
-        send(PrepareGameRequest(gameType))
+        client.send(PrepareGameRequest(gameType))
     }
     
     fun prepareGame(gameType: String, startPaused: Boolean) {
-        send(PrepareGameRequest(
+        client.send(PrepareGameRequest(
                 gameType,
                 SlotDescriptor("player1", false),
                 SlotDescriptor("player2", false),
@@ -42,7 +31,7 @@ class AdminClient(host: String, port: Int, password: String, private val message
      * @param isPaused whether the game to observe is already paused.
      */
     fun observeAndControl(roomId: String, isPaused: Boolean): IControllableGame {
-        val controller = ControllingClient(this, roomId, isPaused)
+        val controller = ControllingClient(client, roomId, isPaused)
         requestObservation(roomId)
         return controller
     }
@@ -58,12 +47,11 @@ class AdminClient(host: String, port: Int, password: String, private val message
     }
     
     private fun requestObservation(roomId: String) {
-        start()
-        send(ObservationRequest(roomId))
+        client.send(ObservationRequest(roomId))
     }
     
     fun freeReservation(reservation: String) {
-        send(FreeReservationRequest(reservation))
+        client.send(FreeReservationRequest(reservation))
     }
     
 }

--- a/sdk/src/server-api/sc/networking/clients/ControllingClient.java
+++ b/sdk/src/server-api/sc/networking/clients/ControllingClient.java
@@ -11,11 +11,11 @@ import sc.protocol.requests.StepRequest;
 public class ControllingClient extends ObservingClient implements IAdministrativeListener {
   private static final Logger logger = LoggerFactory.getLogger(ControllingClient.class);
 
-  final LobbyClient client;
+  private final XStreamClient client;
   private boolean allowOneStep = false;
   private boolean pauseHitReceived;
 
-  public ControllingClient(LobbyClient client, String roomId, boolean isPaused) {
+  public ControllingClient(XStreamClient client, String roomId, boolean isPaused) {
     super(roomId, isPaused);
     this.client = client;
   }

--- a/sdk/src/server-api/sc/networking/clients/GameController.kt
+++ b/sdk/src/server-api/sc/networking/clients/GameController.kt
@@ -1,0 +1,11 @@
+package sc.networking.clients
+
+import sc.protocol.requests.CancelRequest
+import sc.protocol.requests.PauseGameRequest
+import sc.protocol.requests.StepRequest
+
+class GameController(private val roomId: String, private val client: XStreamClient): IGameController {
+    override fun step() = client.send(StepRequest(roomId))
+    override fun pause(pause: Boolean) = client.send(PauseGameRequest(roomId, pause))
+    override fun cancel() = client.send(CancelRequest(roomId))
+}

--- a/sdk/src/server-api/sc/networking/clients/IGameController.kt
+++ b/sdk/src/server-api/sc/networking/clients/IGameController.kt
@@ -1,0 +1,8 @@
+package sc.networking.clients
+
+interface IGameController {
+    fun step()
+    fun pause(pause: Boolean = true)
+    fun unpause() = pause(false)
+    fun cancel()
+}

--- a/sdk/src/server-api/sc/networking/clients/LobbyClient.java
+++ b/sdk/src/server-api/sc/networking/clients/LobbyClient.java
@@ -4,14 +4,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sc.api.plugins.IGameState;
 import sc.framework.plugins.Player;
-import sc.protocol.RemovedFromGame;
 import sc.protocol.ProtocolPacket;
+import sc.protocol.RemovedFromGame;
 import sc.protocol.ResponsePacket;
 import sc.protocol.requests.*;
 import sc.protocol.responses.*;
 import sc.protocol.room.*;
 import sc.shared.GameResult;
-import sc.shared.SlotDescriptor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,7 +29,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
   private static final Logger logger = LoggerFactory.getLogger(LobbyClient.class);
   private final List<ILobbyClientListener> listeners = new ArrayList<>();
   private final List<IHistoryListener> historyListeners = new ArrayList<>();
-  private final List<IAdministrativeListener> administrativeListeners = new ArrayList<>();
 
   private Consumer<ResponsePacket> administrativeListener = null;
 
@@ -85,10 +83,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
   }
 
   private void onGamePaused(String roomId, Player nextPlayer) {
-    for (IAdministrativeListener listener : this.administrativeListeners) {
-      listener.onGamePaused(roomId, nextPlayer);
-    }
-
     for (ILobbyClientListener listener : this.listeners) {
       listener.onGamePaused(roomId, nextPlayer);
     }
@@ -181,23 +175,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
     this.listeners.remove(listener);
   }
 
-  /** Takes control of the game in the given room and pauses it. */
-  public IControllableGame observeAndControl(String roomId) {
-    final IControllableGame controller = observeAndControl(roomId, true);
-    controller.pause();
-    return controller;
-  }
-
-  /** Takes control of the game in the given room.
-   * @param isPaused whether the game to observe is already paused. */
-  public IControllableGame observeAndControl(String roomId, boolean isPaused) {
-    ControllingClient controller = new ControllingClient(this, roomId, isPaused);
-    addListener((IAdministrativeListener) controller);
-    addListener((IHistoryListener) controller);
-    requestObservation(roomId);
-    return controller;
-  }
-
   public ObservingClient observe(String roomId) {
     return observe(roomId, false);
   }
@@ -223,14 +200,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
   @Override
   public void removeListener(IHistoryListener listener) {
     this.historyListeners.remove(listener);
-  }
-
-  public void addListener(IAdministrativeListener listener) {
-    this.administrativeListeners.add(listener);
-  }
-
-  public void removeListener(IAdministrativeListener listener) {
-    this.administrativeListeners.remove(listener);
   }
 
 }

--- a/sdk/src/server-api/sc/networking/clients/LobbyClient.java
+++ b/sdk/src/server-api/sc/networking/clients/LobbyClient.java
@@ -14,7 +14,9 @@ import sc.shared.GameResult;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -30,6 +32,7 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
   private final List<ILobbyClientListener> listeners = new ArrayList<>();
   private final List<IHistoryListener> historyListeners = new ArrayList<>();
 
+  private final Map<String, Consumer<RoomMessage>> roomObservers = new HashMap<>();
   private Consumer<ResponsePacket> administrativeListener = null;
 
   public LobbyClient(String host, int port) throws IOException {
@@ -182,14 +185,12 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
   public ObservingClient observe(String roomId, boolean isPaused) {
     ObservingClient observer = new ObservingClient(roomId, isPaused);
     addListener(observer);
-    requestObservation(roomId);
+    send(new ObservationRequest(roomId));
     return observer;
   }
 
-  private void requestObservation(String roomId) {
-    start();
-    logger.debug("Sending observation request for roomId: {}", roomId);
-    send(new ObservationRequest(roomId));
+  public void observeRoom(String roomId, Consumer<RoomMessage> observer) {
+    roomObservers.put(roomId, observer);
   }
 
   @Override

--- a/sdk/src/server-api/sc/networking/clients/LobbyClient.java
+++ b/sdk/src/server-api/sc/networking/clients/LobbyClient.java
@@ -189,6 +189,9 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
     return observer;
   }
 
+  /** Sets observer to observe messages in the given room.
+   * Whether administrative messages are received depends on authentication,
+   * which has to be done separately. */
   public void observeRoom(String roomId, Consumer<RoomMessage> observer) {
     roomObservers.put(roomId, observer);
   }

--- a/sdk/src/server-api/sc/networking/clients/LobbyClient.java
+++ b/sdk/src/server-api/sc/networking/clients/LobbyClient.java
@@ -130,19 +130,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
     send(new AuthenticateRequest(password));
   }
 
-  public void prepareGame(String gameType) {
-    send(new PrepareGameRequest(gameType));
-  }
-
-  public void prepareGame(String gameType, boolean startPaused) {
-    send(new PrepareGameRequest(
-        gameType,
-        new SlotDescriptor("player1", false),
-        new SlotDescriptor("player2", false),
-        startPaused)
-    );
-  }
-
   protected void onCustomObject(Object o) {
     logger.warn("Couldn't process message {}.", o);
   }
@@ -232,10 +219,6 @@ public final class LobbyClient extends XStreamClient implements IPollsHistory {
 
   public void removeListener(IAdministrativeListener listener) {
     this.administrativeListeners.remove(listener);
-  }
-
-  public void freeReservation(String reservation) {
-    send(new FreeReservationRequest(reservation));
   }
 
 }

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -12,6 +12,7 @@ import sc.framework.plugins.Player;
 import sc.framework.HelperMethods;
 import sc.networking.InvalidScoreDefinitionException;
 import sc.networking.XStreamProvider;
+import sc.networking.clients.AdminClient;
 import sc.networking.clients.LobbyClient;
 import sc.networking.clients.ObservingClient;
 import sc.networking.clients.XStreamClient;
@@ -70,8 +71,8 @@ public class GameRoom implements IGameListener {
         logger.debug("Save replay is active and try to save it to file");
         LobbyClient lobbyClient = new LobbyClient("127.0.0.1", Configuration.getPort());
         lobbyClient.start();
-        lobbyClient.authenticate(Configuration.getAdministrativePassword());
-        replayObserver = lobbyClient.observe(getId());
+        AdminClient admin = lobbyClient.authenticate(Configuration.getAdministrativePassword(), null);
+        replayObserver = admin.observe(getId());
       } catch (IOException e) {
         logger.warn("Failed to start replay recording");
         e.printStackTrace();

--- a/server/src/sc/server/gaming/GameRoom.java
+++ b/server/src/sc/server/gaming/GameRoom.java
@@ -65,19 +65,6 @@ public class GameRoom implements IGameListener {
     this.game = game;
     this.prepared = prepared;
     game.addGameListener(this);
-
-    if (Boolean.parseBoolean(Configuration.get(Configuration.SAVE_REPLAY))) {
-      try {
-        logger.debug("Save replay is active and try to save it to file");
-        LobbyClient lobbyClient = new LobbyClient("127.0.0.1", Configuration.getPort());
-        lobbyClient.start();
-        AdminClient admin = lobbyClient.authenticate(Configuration.getAdministrativePassword(), null);
-        replayObserver = admin.observe(getId());
-      } catch (IOException e) {
-        logger.warn("Failed to start replay recording");
-        e.printStackTrace();
-      }
-    }
   }
 
   /** Generate Game Result, set status to OVER and remove from manager. */

--- a/server/test/sc/server/client/MessageListener.kt
+++ b/server/test/sc/server/client/MessageListener.kt
@@ -1,0 +1,39 @@
+package sc.server.client
+
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.should
+import io.kotest.matchers.types.beInstanceOf
+import kotlinx.coroutines.runBlocking
+import sc.server.network.await
+import java.util.ArrayDeque
+import java.util.Queue
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
+import kotlin.time.ExperimentalTime
+
+open class MessageListener<T: Any> {
+    private val messages: Queue<T> = ArrayDeque()
+    
+    fun addMessage(message: T) =
+            messages.add(message)
+    
+    /** Clears all messages.
+     * @return number of cleared messages */
+    fun clearMessages(): Int {
+        val size = messages.size
+        messages.clear()
+        return size
+    }
+    
+    /** Waits until a message arrives and asserts its type.
+     * @return the message. */
+    @ExperimentalTime
+    fun <U: T> waitForMessage(messageType: KClass<out U>) = runBlocking {
+        await("Expected to receive ${messageType.simpleName}") {
+            messages.shouldNotBeEmpty()
+        }
+        val msg = messages.remove()
+        msg should beInstanceOf(messageType)
+        messageType.cast(msg)
+    }
+}

--- a/server/test/sc/server/client/PlayerListener.kt
+++ b/server/test/sc/server/client/PlayerListener.kt
@@ -1,36 +1,10 @@
 package sc.server.client
 
-import io.kotest.matchers.collections.shouldNotBeEmpty
-import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.runBlocking
 import sc.api.plugins.host.IPlayerListener
 import sc.protocol.room.RoomMessage
-import sc.server.network.await
-import java.util.Queue
-import java.util.ArrayDeque
-import kotlin.reflect.KClass
-import kotlin.time.ExperimentalTime
 
-class PlayerListener : IPlayerListener {
-    private val messages: Queue<RoomMessage> = ArrayDeque()
-
+class PlayerListener : MessageListener<RoomMessage>(), IPlayerListener {
     override fun onPlayerEvent(request: RoomMessage) {
-        messages.add(request)
-    }
-    
-    /** Clears all messages.
-     * @return number of cleared messages */
-    fun clearMessages(): Int {
-        val size = messages.size
-        messages.clear()
-        return size
-    }
-    
-    @ExperimentalTime
-    fun waitForMessage(messageType: KClass<out RoomMessage>) = runBlocking {
-        await("Expected to receive ${messageType.simpleName}") {
-            messages.shouldNotBeEmpty()
-        }
-        messages.remove()::class shouldBe messageType
+        addMessage(request)
     }
 }

--- a/server/test/sc/server/network/LobbyRequestTest.kt
+++ b/server/test/sc/server/network/LobbyRequestTest.kt
@@ -7,14 +7,25 @@ import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 import sc.framework.plugins.protocol.MoveRequest
+import sc.networking.clients.AdminClient
+import sc.protocol.ProtocolPacket
+import sc.protocol.requests.JoinPreparedRoomRequest
+import sc.protocol.responses.ErrorMessage
+import sc.protocol.responses.ErrorPacket
+import sc.protocol.responses.GamePreparedResponse
+import sc.protocol.responses.ObservationResponse
 import sc.server.client.PlayerListener
-import sc.server.client.TestLobbyClientListener
 import sc.server.gaming.GameRoom
 import sc.server.plugins.TestGame
 import sc.server.plugins.TestMove
 import sc.server.plugins.TestPlugin
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
@@ -28,28 +39,31 @@ suspend fun await(clue: String? = null, duration: Duration = 1.seconds, interval
 class LobbyRequestTest: WordSpec({
     "A Lobby with connected clients" When {
         val lobby = autoClose(TestLobby())
-        val players = Array(3) { lobby.connectClient("localhost", lobby.serverPort) }
-        await("Clients connected") { lobby.clientManager.clients.size shouldBe players.size }
+    
+        val messages = ArrayDeque<ProtocolPacket>()
+        suspend fun <T : ProtocolPacket> awaitMessage(clue: String? = null, clazz: KClass<T>): T {
+            await(clue) { messages.shouldNotBeEmpty() }
+            val msg = messages.removeFirst()
+            msg should beInstanceOf(clazz)
+            return clazz.cast(msg)
+        }
+        
+        val admin = AdminClient("localhost", lobby.serverPort, PASSWORD, messages::add)
+        val players = Array(2) { lobby.connectClient() }
+        await("Clients connected") { lobby.clientManager.clients.size shouldBe 3 }
         "a player joined" should {
             players[0].joinRoomRequest(TestPlugin.TEST_PLUGIN_UUID)
             "create a room for it" {
-                withClue("Room opened") {
-                    await { lobby.games.size shouldBe 1 }
-                }
+                await("Room opened") { lobby.games.size shouldBe 1 }
                 lobby.games.single().clients shouldHaveSize 1
             }
         }
-        val admin = players[0]
         "a game is prepared paused" should {
-            val listener = TestLobbyClientListener()
-            admin.addListener(listener)
-            admin.authenticate(PASSWORD)
-            
             admin.prepareGame(TestPlugin.TEST_PLUGIN_UUID, true)
-            await("GameRoom prepared") { listener.gamePreparedReceived shouldBe true }
+            val prepared = awaitMessage("GameRoom prepared", GamePreparedResponse::class)
             lobby.games shouldHaveSize 1
             
-            val roomId = listener.prepareGameResponse.roomId
+            val roomId = prepared.roomId
             val room = lobby.findRoom(roomId)
             withClue("GameRoom is empty and paused") {
                 room.clients.shouldBeEmpty()
@@ -57,40 +71,41 @@ class LobbyRequestTest: WordSpec({
             }
             
             val observer = admin.observeAndControl(roomId, true)
-            await("Game observed") { println(listener); listener.observedReceived shouldBe true }
+            awaitMessage("Game observed", ObservationResponse::class)
             
-            val reservations = listener.prepareGameResponse.reservations
-            players[1].joinPreparedGame(reservations[0])
+            val reservations = prepared.reservations
+            players[0].joinPreparedGame(reservations[0])
             await("First player joined") { room.clients shouldHaveSize 1 }
             "not accept a reservation twice" {
-                admin.joinPreparedGame(reservations[0])
-                await("Receive error when reusing a reservation") { listener.errorReceived shouldBe true }
+                admin.send(JoinPreparedRoomRequest(reservations[0]))
+                awaitMessage("Receive error when reusing a reservation", ErrorPacket::class)
                 room.clients shouldHaveSize 1
                 lobby.games shouldHaveSize 1
             }
-            players[2].joinPreparedGame(reservations[1])
+            players[1].joinPreparedGame(reservations[1])
             await("Players join, Game start") { room.status shouldBe GameRoom.GameStatus.ACTIVE }
             
             val playerListeners = room.slots.map { slot ->
                 PlayerListener().also { listener -> slot.role.player.addPlayerListener(listener) }
             }
             "terminate when a Move is received while still paused" {
-                players[1].sendMessageToRoom(roomId, TestMove(0))
+                players[0].sendMessageToRoom(roomId, TestMove(0))
                 await("Terminates") { room.status shouldBe GameRoom.GameStatus.OVER }
             }
             "play game on unpause" {
                 observer.unpause()
                 await { room.isPauseRequested shouldBe false }
                 val game = room.game as TestGame
+                game.isPaused shouldBe false
                 withClue("Processes moves") {
                     playerListeners[0].waitForMessage(MoveRequest::class)
-                    players[1].sendMessageToRoom(roomId, TestMove(32))
+                    players[0].sendMessageToRoom(roomId, TestMove(32))
                     await { game.currentState.state shouldBe 32 }
                     playerListeners[1].waitForMessage(MoveRequest::class)
-                    players[2].sendMessageToRoom(roomId, TestMove(54))
+                    players[1].sendMessageToRoom(roomId, TestMove(54))
                     await { game.currentState.state shouldBe 54 }
                 }
-                players[2].sendMessageToRoom(roomId, TestMove(0))
+                players[1].sendMessageToRoom(roomId, TestMove(0))
                 await("Terminate after wrong player sent a turn") {
                     room.status shouldBe GameRoom.GameStatus.OVER
                 }

--- a/server/test/sc/server/network/LobbyRequestTest.kt
+++ b/server/test/sc/server/network/LobbyRequestTest.kt
@@ -62,9 +62,6 @@ class LobbyRequestTest: WordSpec({
                 room.isPauseRequested shouldBe true
             }
             
-            val observer = admin.observeAndControl(roomId, true)
-            adminListener.waitForMessage(ObservationResponse::class)
-            
             val reservations = prepared.reservations
             players[0].joinPreparedGame(reservations[0])
             await("First player joined") { room.clients shouldHaveSize 1 }
@@ -85,7 +82,7 @@ class LobbyRequestTest: WordSpec({
                 await("Terminates") { room.status shouldBe GameRoom.GameStatus.OVER }
             }
             "play game on unpause" {
-                observer.unpause()
+                admin.control(roomId).unpause()
                 await { room.isPauseRequested shouldBe false }
                 val game = room.game as TestGame
                 game.isPaused shouldBe false

--- a/server/test/sc/server/network/LobbyRequestTest.kt
+++ b/server/test/sc/server/network/LobbyRequestTest.kt
@@ -13,6 +13,7 @@ import sc.framework.plugins.protocol.MoveRequest
 import sc.networking.clients.LobbyClient
 import sc.protocol.ResponsePacket
 import sc.protocol.requests.JoinPreparedRoomRequest
+import sc.protocol.requests.PrepareGameRequest
 import sc.protocol.responses.ErrorPacket
 import sc.protocol.responses.GamePreparedResponse
 import sc.protocol.responses.ObservationResponse
@@ -51,7 +52,7 @@ class LobbyRequestTest: WordSpec({
             }
         }
         "a game is prepared paused" should {
-            admin.prepareGame(TestPlugin.TEST_PLUGIN_UUID, true)
+            admin.prepareGame(PrepareGameRequest(TestPlugin.TEST_PLUGIN_UUID, pause = true))
             val prepared = adminListener.waitForMessage(GamePreparedResponse::class)
             lobby.games shouldHaveSize 1
             

--- a/server/test/sc/server/network/TestLobby.kt
+++ b/server/test/sc/server/network/TestLobby.kt
@@ -1,15 +1,10 @@
 package sc.server.network
 
-import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 import sc.networking.clients.LobbyClient
 import sc.server.Configuration
 import sc.server.Lobby
-import sc.server.helpers.TestHelper
 import sc.server.plugins.TestPlugin
-import java.io.IOException
-import java.net.Socket
-import java.util.concurrent.TimeUnit
 
 internal const val PASSWORD = "TEST_PASSWORD"
 
@@ -36,28 +31,10 @@ class TestLobby: Lobby() {
         }
     }
     
-    fun connectClient(host: String, port: Int): LobbyClient {
-        val client = LobbyClient(host, port)
+    fun connectClient(): LobbyClient {
+        val client = LobbyClient("localhost", serverPort)
         client.start()
         return client
-    }
-    
-    fun waitForConnect(count: Int) =
-        TestHelper.assertEqualsWithTimeout(count, { clientManager.clients.size }, 1, TimeUnit.SECONDS)
-    
-    fun connectClient(): TestTcpClient {
-        try {
-            if (serverPort == 0)
-                throw RuntimeException("Could not find an open port to connect to.")
-            val mySocket = Socket("localhost",
-                NewClientListener.lastUsedPort)
-            val result = TestTcpClient(mySocket)
-            result.start()
-            return result
-        } catch (e: IOException) {
-            e.printStackTrace()
-            fail("Could not connect to server.")
-        }
     }
     
 }


### PR DESCRIPTION
This is the first part, which will only tackle the server/gui-side with the AdminClient. Thus this feature may still be released in the current season.
It provides a polished interface where listening and controlling is cleanly separated, and requests have appropriate preconditions (LobbyClient yields an AdminClient upon authentication).

The old Java `RequestTest` will also have to be retired along the way, but I'm a bit worried that the new tests don't yet replace it fully.

I already have an idea of how to make this compatible with the PlayerClient, but that will have to wait.

Based on #396, so don't be overwhelmed by the changelist.